### PR TITLE
Fix UserManager docs and custom token audience in password reset

### DIFF
--- a/docs/configuration/user-manager.md
+++ b/docs/configuration/user-manager.md
@@ -171,7 +171,7 @@ from fastapi_users import BaseUserManager
 
 class UserManager(BaseUserManager[UserCreate, UserDB]):
     # ...
-    async def on_after_request_verify(
+    async def on_after_verify(
         self, user: UserDB, request: Optional[Request] = None
     ):
         print(f"User {user.id} has been verified")
@@ -197,7 +197,7 @@ from fastapi_users import BaseUserManager
 
 class UserManager(BaseUserManager[UserCreate, UserDB]):
     # ...
-    async def on_after_request_verify(
+    async def on_after_forgot_password(
         self, user: UserDB, token: str, request: Optional[Request] = None
     ):
         print(f"User {user.id} has forgot their password. Reset token: {token}")

--- a/fastapi_users/manager.py
+++ b/fastapi_users/manager.py
@@ -307,7 +307,7 @@ class BaseUserManager(Generic[models.UC, models.UD]):
         if not user.is_active:
             raise UserInactive()
 
-        token_data = {"user_id": str(user.id), "aud": RESET_PASSWORD_TOKEN_AUDIENCE}
+        token_data = {"user_id": str(user.id), "aud": self.reset_password_token_audience}
         token = generate_jwt(
             token_data,
             self.reset_password_token_secret,


### PR DESCRIPTION
I noticed that the functions in the docs are named incorrectly so I fixed it 😃 
Also, I saw that when using custom a token audience in the password reset feature, the creation of the token still uses the default value instead of the custom one.