### PR TITLE
Users now become unverified when email is changed

### DIFF
--- a/fastapi_users/manager.py
+++ b/fastapi_users/manager.py
@@ -545,6 +545,7 @@ class BaseUserManager(Generic[models.UC, models.UD]):
                     raise UserAlreadyExists()
                 except UserNotExists:
                     user.email = value
+                    user.is_verified = False
             elif field == "password":
                 await self.validate_password(value, user)
                 hashed_password = get_password_hash(value)

--- a/tests/test_router_users.py
+++ b/tests/test_router_users.py
@@ -202,6 +202,21 @@ class TestUpdateMe:
             data = cast(Dict[str, Any], response.json())
             assert data["email"] == "king.arthur@tintagel.bt"
 
+    async def test_unvalidated_after_email_change(
+        self,
+        test_app_client: Tuple[httpx.AsyncClient, bool],
+        verified_user: UserDB,
+    ):
+        client, _ = test_app_client
+        json = {"email": "king.arthur@tintagel.bt"}
+        response = await client.patch(
+            "/me", json=json, headers={"Authorization": f"Bearer {verified_user.id}"}
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        data = cast(Dict[str, Any], response.json())
+        assert data["is_verified"] is False
+
     async def test_valid_body_is_superuser(
         self,
         test_app_client: Tuple[httpx.AsyncClient, bool],

--- a/tests/test_router_users.py
+++ b/tests/test_router_users.py
@@ -202,7 +202,7 @@ class TestUpdateMe:
             data = cast(Dict[str, Any], response.json())
             assert data["email"] == "king.arthur@tintagel.bt"
 
-    async def test_unvalidated_after_email_change(
+    async def test_unverified_after_email_change(
         self,
         test_app_client: Tuple[httpx.AsyncClient, bool],
         verified_user: UserDB,


### PR DESCRIPTION
This occurs when updating user.email to a new value.

Related to #778 