### PR TITLE
Use scopes

### DIFF
--- a/fastapi_users/authentication/base.py
+++ b/fastapi_users/authentication/base.py
@@ -49,3 +49,6 @@ class BaseAuthentication(Generic[T, models.UC, models.UD]):
         user_manager: BaseUserManager[models.UC, models.UD],
     ) -> Any:
         raise NotImplementedError()
+
+    async def decode_jwt(self, token: str) -> dict:
+        raise NotImplementedError

--- a/fastapi_users/authentication/jwt.py
+++ b/fastapi_users/authentication/jwt.py
@@ -1,4 +1,4 @@
-from typing import Any, Generic, List, Optional
+from typing import Any, Generic, List, Optional, Dict
 
 import jwt
 from fastapi import Response
@@ -36,9 +36,13 @@ class JWTAuthentication(
         tokenUrl: str = "auth/jwt/login",
         name: str = "jwt",
         token_audience: List[str] = ["fastapi-users:auth"],
+        security_scopes: Optional[Dict[str, str]] = None
     ):
         super().__init__(name, logout=False)
-        self.scheme = OAuth2PasswordBearer(tokenUrl, auto_error=False)
+        if security_scopes is not None:
+            self.scheme = OAuth2PasswordBearer(tokenUrl, auto_error=False, scopes=security_scopes)
+        else:
+            self.scheme = OAuth2PasswordBearer(tokenUrl, auto_error=False)
         self.secret = secret
         self.token_audience = token_audience
         self.lifetime_seconds = lifetime_seconds

--- a/fastapi_users/authentication/jwt.py
+++ b/fastapi_users/authentication/jwt.py
@@ -78,4 +78,10 @@ class JWTAuthentication(
 
     async def _generate_token(self, user: models.UD) -> str:
         data = {"user_id": str(user.id), "aud": self.token_audience}
+        if user.scopes:
+            data["scopes"] = user.scopes
         return generate_jwt(data, self.secret, self.lifetime_seconds)
+
+    async def decode_jwt(self, token: str) -> dict:
+        data = decode_jwt(token, self.secret, self.token_audience)
+        return data

--- a/fastapi_users/models.py
+++ b/fastapi_users/models.py
@@ -1,7 +1,7 @@
 import uuid
 from typing import List, Optional, TypeVar
 
-from pydantic import UUID4, BaseModel, EmailStr, Field
+from pydantic import UUID4, BaseModel, EmailStr, Field, conlist
 
 
 class CreateUpdateDictModel(BaseModel):
@@ -29,6 +29,7 @@ class BaseUser(CreateUpdateDictModel):
     is_active: bool = True
     is_superuser: bool = False
     is_verified: bool = False
+    scopes: conlist(str) = []
 
 
 class BaseUserCreate(CreateUpdateDictModel):
@@ -37,6 +38,7 @@ class BaseUserCreate(CreateUpdateDictModel):
     is_active: Optional[bool] = True
     is_superuser: Optional[bool] = False
     is_verified: Optional[bool] = False
+    scopes: Optional[conlist(str)] = []
 
 
 class BaseUserUpdate(CreateUpdateDictModel):
@@ -45,6 +47,7 @@ class BaseUserUpdate(CreateUpdateDictModel):
     is_active: Optional[bool]
     is_superuser: Optional[bool]
     is_verified: Optional[bool]
+    scopes: Optional[conlist(str)]
 
 
 class BaseUserDB(BaseUser):

--- a/fastapi_users/models.py
+++ b/fastapi_users/models.py
@@ -14,6 +14,7 @@ class CreateUpdateDictModel(BaseModel):
                 "is_active",
                 "is_verified",
                 "oauth_accounts",
+                "scopes"
             },
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires = [
 
 [tool.flit.metadata.requires-extra]
 sqlalchemy = [
-    "fastapi-users-db-sqlalchemy @ git+https://github.com/fastapi-users-db-sqlalchemy.git",
+    "fastapi-users-db-sqlalchemy @ git+https://github.com/artreven/fastapi-users-db-sqlalchemy.git",
 ]
 mongodb = [
     "fastapi-users-db-mongodb >=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires = [
 
 [tool.flit.metadata.requires-extra]
 sqlalchemy = [
-    "fastapi-users-db-sqlalchemy >=1.0.0",
+    "fastapi-users-db-sqlalchemy @ git+https://github.com/fastapi-users-db-sqlalchemy.git",
 ]
 mongodb = [
     "fastapi-users-db-mongodb >=1.0.0",

--- a/tests/test_authentication.py
+++ b/tests/test_authentication.py
@@ -34,6 +34,9 @@ class BackendNone(
     ) -> Optional[models.UD]:
         return None
 
+    async def decode_jwt(self, token: str):
+        return dict()
+
 
 class BackendUser(
     Generic[models.UC, models.UD], BaseAuthentication[str, models.UC, models.UD]
@@ -49,6 +52,9 @@ class BackendUser(
         user_manager: BaseUserManager[models.UC, models.UD],
     ) -> Optional[models.UD]:
         return self.user
+
+    async def decode_jwt(self, token: str):
+        return dict()
 
 
 @pytest.fixture

--- a/tests/test_authentication_base.py
+++ b/tests/test_authentication_base.py
@@ -29,3 +29,10 @@ async def test_get_login_response(base_authentication, user, user_manager):
 async def test_get_logout_response(base_authentication, user, user_manager):
     with pytest.raises(NotImplementedError):
         await base_authentication.get_logout_response(user, Response(), user_manager)
+
+
+@pytest.mark.authentication
+@pytest.mark.asyncio
+async def test_decode_jwt_response(base_authentication, user):
+    with pytest.raises(NotImplementedError):
+        await base_authentication.decode_jwt(user)


### PR DESCRIPTION
I tried to use scopes inspired by https://fastapi.tiangolo.com/advanced/security/oauth2-scopes/#dependency-tree-and-scopes and discussions in #217 and #219.
The scopes are ingested into the token data, so we can check them without calling the db. However, as I did not want to make changes to existing functionalities, database is still queried on every user request unless the scope check fails.