### PR TITLE
chore: Add FastAPI to Classifiers ✨

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ home-page = "https://github.com/fastapi-users/fastapi-users"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Development Status :: 5 - Production/Stable",
+    "Framework :: FastAPI",
     "Framework :: AsyncIO",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
the PR https://github.com/pypa/trove-classifiers/pull/80 relate to adding FastAPI as a new trove classifier.

the release commit:
https://github.com/pypa/trove-classifiers/commit/4e2248b1fce527e3943358037a1d5db8e8186fd5