### PR TITLE
Removed assignments to a `fastapi_users` variable.

### DIFF
--- a/docs/configuration/routers/auth.md
+++ b/docs/configuration/routers/auth.md
@@ -15,7 +15,7 @@ SECRET = "SECRET"
 
 jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
 
-fastapi_users = FastAPIUsers(
+users = FastAPIUsers(
     get_user_manager,
     [jwt_authentication],
     User,

--- a/docs/configuration/routers/index.md
+++ b/docs/configuration/routers/index.md
@@ -17,7 +17,7 @@ Configure `FastAPIUsers` object with all the elements we defined before. More pr
 ```py
 from fastapi_users import FastAPIUsers
 
-fastapi_users = FastAPIUsers(
+users = FastAPIUsers(
     get_user_manager,
     [jwt_authentication],
     User,

--- a/docs/configuration/routers/register.md
+++ b/docs/configuration/routers/register.md
@@ -15,7 +15,7 @@ SECRET = "SECRET"
 
 jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
 
-fastapi_users = FastAPIUsers(
+users = FastAPIUsers(
     get_user_manager,
     [jwt_authentication],
     User,

--- a/docs/configuration/routers/reset.md
+++ b/docs/configuration/routers/reset.md
@@ -14,7 +14,7 @@ SECRET = "SECRET"
 
 jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
 
-fastapi_users = FastAPIUsers(
+users = FastAPIUsers(
     get_user_manager,
     [jwt_authentication],
     User,

--- a/docs/configuration/routers/users.md
+++ b/docs/configuration/routers/users.md
@@ -12,7 +12,7 @@ SECRET = "SECRET"
 
 jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
 
-fastapi_users = FastAPIUsers(
+users = FastAPIUsers(
     get_user_manager,
     [jwt_authentication],
     User,

--- a/docs/configuration/routers/verify.md
+++ b/docs/configuration/routers/verify.md
@@ -15,7 +15,7 @@ SECRET = "SECRET"
 
 jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
 
-fastapi_users = FastAPIUsers(
+users = FastAPIUsers(
     get_user_manager,
     [jwt_authentication],
     User,

--- a/docs/migration/08_to_1x.md
+++ b/docs/migration/08_to_1x.md
@@ -131,7 +131,7 @@ You now have the responsibility to **wire the routers**. FastAPI Users doesn't g
 jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
 
 app = FastAPI()
-fastapi_users = FastAPIUsers(
+users = FastAPIUsers(
     user_db, [jwt_authentication], User, UserCreate, UserUpdate, UserDB,
 )
 app.include_router(fastapi_users.router, prefix="/users", tags=["users"])
@@ -161,7 +161,7 @@ def on_after_forgot_password(user: UserDB, token: str, request: Request):
 jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=3600)
 
 app = FastAPI()
-fastapi_users = FastAPIUsers(
+users = FastAPIUsers(
     user_db, [jwt_authentication], User, UserCreate, UserUpdate, UserDB,
 )
 app.include_router(

--- a/tests/test_fastapi_users.py
+++ b/tests/test_fastapi_users.py
@@ -58,9 +58,7 @@ async def test_app_client(
 
     @app.get("/current-verified-superuser")
     def current_verified_superuser(
-        user=Depends(
-            users.current_user(active=True, verified=True, superuser=True)
-        ),
+        user=Depends(users.current_user(active=True, verified=True, superuser=True)),
     ):
         return user
 
@@ -82,9 +80,7 @@ async def test_app_client(
 
     @app.get("/optional-current-superuser")
     def optional_current_superuser(
-        user=Depends(
-            users.current_user(optional=True, active=True, superuser=True)
-        ),
+        user=Depends(users.current_user(optional=True, active=True, superuser=True)),
     ):
         return user
 

--- a/tests/test_fastapi_users.py
+++ b/tests/test_fastapi_users.py
@@ -17,7 +17,7 @@ async def test_app_client(
     oauth_client,
     get_test_client,
 ) -> AsyncGenerator[httpx.AsyncClient, None]:
-    fastapi_users = FastAPIUsers[User, UserCreate, UserUpdate, UserDB](
+    users = FastAPIUsers[User, UserCreate, UserUpdate, UserDB](
         get_user_manager,
         [mock_authentication],
         User,
@@ -27,63 +27,63 @@ async def test_app_client(
     )
 
     app = FastAPI()
-    app.include_router(fastapi_users.get_register_router())
-    app.include_router(fastapi_users.get_reset_password_router())
-    app.include_router(fastapi_users.get_auth_router(mock_authentication))
-    app.include_router(fastapi_users.get_oauth_router(oauth_client, secret))
-    app.include_router(fastapi_users.get_users_router(), prefix="/users")
-    app.include_router(fastapi_users.get_verify_router())
+    app.include_router(users.get_register_router())
+    app.include_router(users.get_reset_password_router())
+    app.include_router(users.get_auth_router(mock_authentication))
+    app.include_router(users.get_oauth_router(oauth_client, secret))
+    app.include_router(users.get_users_router(), prefix="/users")
+    app.include_router(users.get_verify_router())
 
     @app.delete("/users/me")
     def custom_users_route():
         return None
 
     @app.get("/current-user")
-    def current_user(user=Depends(fastapi_users.current_user())):
+    def current_user(user=Depends(users.current_user())):
         return user
 
     @app.get("/current-active-user")
-    def current_active_user(user=Depends(fastapi_users.current_user(active=True))):
+    def current_active_user(user=Depends(users.current_user(active=True))):
         return user
 
     @app.get("/current-verified-user")
-    def current_verified_user(user=Depends(fastapi_users.current_user(verified=True))):
+    def current_verified_user(user=Depends(users.current_user(verified=True))):
         return user
 
     @app.get("/current-superuser")
     def current_superuser(
-        user=Depends(fastapi_users.current_user(active=True, superuser=True))
+        user=Depends(users.current_user(active=True, superuser=True))
     ):
         return user
 
     @app.get("/current-verified-superuser")
     def current_verified_superuser(
         user=Depends(
-            fastapi_users.current_user(active=True, verified=True, superuser=True)
+            users.current_user(active=True, verified=True, superuser=True)
         ),
     ):
         return user
 
     @app.get("/optional-current-user")
-    def optional_current_user(user=Depends(fastapi_users.current_user(optional=True))):
+    def optional_current_user(user=Depends(users.current_user(optional=True))):
         return user
 
     @app.get("/optional-current-active-user")
     def optional_current_active_user(
-        user=Depends(fastapi_users.current_user(optional=True, active=True)),
+        user=Depends(users.current_user(optional=True, active=True)),
     ):
         return user
 
     @app.get("/optional-current-verified-user")
     def optional_current_verified_user(
-        user=Depends(fastapi_users.current_user(optional=True, verified=True)),
+        user=Depends(users.current_user(optional=True, verified=True)),
     ):
         return user
 
     @app.get("/optional-current-superuser")
     def optional_current_superuser(
         user=Depends(
-            fastapi_users.current_user(optional=True, active=True, superuser=True)
+            users.current_user(optional=True, active=True, superuser=True)
         ),
     ):
         return user
@@ -91,7 +91,7 @@ async def test_app_client(
     @app.get("/optional-current-verified-superuser")
     def optional_current_verified_superuser(
         user=Depends(
-            fastapi_users.current_user(
+            users.current_user(
                 optional=True, active=True, verified=True, superuser=True
             )
         ),


### PR DESCRIPTION
On several spots in the docs, the `FastAPIUsers` instance was called `fastapi_users`, potentially leading people to name shadowing. I renamed the variable in those examples to `users`. I also renamed a variable of the same name in tests.