### PR TITLE
Fixed #823

### DIFF
--- a/fastapi_users/authentication/__init__.py
+++ b/fastapi_users/authentication/__init__.py
@@ -1,3 +1,4 @@
+import enum
 import re
 from inspect import Parameter, Signature
 from typing import Callable, Optional, Sequence
@@ -42,6 +43,7 @@ class Authenticator:
     """
 
     backends: Sequence[BaseAuthentication]
+    backends_enum: enum.Enum
 
     def __init__(
         self,
@@ -49,6 +51,10 @@ class Authenticator:
         get_user_manager: UserManagerDependency[models.UC, models.UD],
     ):
         self.backends = backends
+        self.backends_enum = enum.Enum(  # type: ignore
+            "AuthenticationBackendName",
+            {backend.name: backend.name for backend in backends},  # type: ignore
+        )
         self.get_user_manager = get_user_manager
 
     def current_user(

--- a/fastapi_users/router/oauth.py
+++ b/fastapi_users/router/oauth.py
@@ -43,10 +43,6 @@ def get_oauth_router(
             route_name=callback_route_name,
         )
 
-    # matches name of first backend OR name of second backend OR ...
-    auth_backend_names = [backend.name for backend in authenticator.backends]
-    auth_backend_regex = "^(" + "|".join(auth_backend_names) + ")$"
-
     @router.get(
         "/authorize",
         name="oauth:authorize",
@@ -54,7 +50,7 @@ def get_oauth_router(
     )
     async def authorize(
         request: Request,
-        authentication_backend: str = Query(..., regex=auth_backend_regex),
+        authentication_backend: authenticator.backends_enum,  # type: ignore
         scopes: List[str] = Query(None),
     ):
         if redirect_url is not None:

--- a/fastapi_users/router/oauth.py
+++ b/fastapi_users/router/oauth.py
@@ -1,4 +1,3 @@
-import enum
 from typing import Dict, List
 
 import jwt
@@ -45,7 +44,8 @@ def get_oauth_router(
         )
 
     # matches name of first backend OR name of second backend OR ...
-    auth_backend_regex = "^(" + "|".join(backend.name for backend in authenticator.backends) + ")$"
+    auth_backend_names = [backend.name for backend in authenticator.backends]
+    auth_backend_regex = "^(" + "|".join(auth_backend_names) + ")$"
 
     @router.get(
         "/authorize",

--- a/fastapi_users/router/oauth.py
+++ b/fastapi_users/router/oauth.py
@@ -44,10 +44,8 @@ def get_oauth_router(
             route_name=callback_route_name,
         )
 
-    AuthenticationBackendName: enum.EnumMeta = enum.Enum(
-        "AuthenticationBackendName",
-        {backend.name: backend.name for backend in authenticator.backends},
-    )
+    # matches name of first backend OR name of second backend OR ...
+    auth_backend_regex = "^(" + "|".join(backend.name for backend in authenticator.backends) + ")$"
 
     @router.get(
         "/authorize",
@@ -56,7 +54,7 @@ def get_oauth_router(
     )
     async def authorize(
         request: Request,
-        authentication_backend: AuthenticationBackendName,
+        authentication_backend: str = Query(..., regex=auth_backend_regex),
         scopes: List[str] = Query(None),
     ):
         if redirect_url is not None:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -1,8 +1,8 @@
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from httpx_oauth.clients.google import GoogleOAuth2
 from httpx_oauth.clients.facebook import FacebookOAuth2
+from httpx_oauth.clients.google import GoogleOAuth2
 
 import fastapi_users.authentication
 from fastapi_users import models
@@ -140,13 +140,15 @@ class TestOAuth2:
         a = FastAPI()
         a.include_router(
             users.get_oauth_router(
-                GoogleOAuth2(client_id="1234", client_secret="4321"), state_secret="secret"
+                GoogleOAuth2(client_id="1234", client_secret="4321"),
+                state_secret="secret",
             ),
             prefix="/google",
         )
         a.include_router(
             users.get_oauth_router(
-                FacebookOAuth2(client_id="1234", client_secret="4321"), state_secret="secret"
+                FacebookOAuth2(client_id="1234", client_secret="4321"),
+                state_secret="secret",
             ),
             prefix="/facebook",
         )

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -2,6 +2,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from httpx_oauth.clients.google import GoogleOAuth2
+from httpx_oauth.clients.facebook import FacebookOAuth2
 
 import fastapi_users.authentication
 from fastapi_users import models
@@ -134,3 +135,19 @@ class TestOAuth2:
     def test_google_callback_status_codes(self, get_openapi_dict):
         route = get_openapi_dict["paths"]["/callback"]["get"]
         assert list(route["responses"].keys()) == ["200", "400", "422"]
+
+    def test_two_oauth_routers(self):
+        a = FastAPI()
+        a.include_router(
+            users.get_oauth_router(
+                GoogleOAuth2(client_id="1234", client_secret="4321"), state_secret="secret"
+            ),
+            prefix="/google",
+        )
+        a.include_router(
+            users.get_oauth_router(
+                FacebookOAuth2(client_id="1234", client_secret="4321"), state_secret="secret"
+            ),
+            prefix="/facebook",
+        )
+        assert TestClient(a).get("/openapi.json").status_code == 200


### PR DESCRIPTION
Closes #823

Basically, FastAPI keeps track of all response models so that they could list them in the generated OpenAPI docs. The dynamic enum from #793 caused an issue with this, because all OAuth routers had a response model of the same name. OpenAPI generation would then crash with a KeyError. 

I added a test for this and switched the OAuth router validation to a regex. It's not as nice for documentation reasons, but I think it's an acceptable solution.