### PR TITLE
logout response sets proper response headers

### DIFF
--- a/fastapi_users/authentication/transport/cookie.py
+++ b/fastapi_users/authentication/transport/cookie.py
@@ -46,8 +46,15 @@ class CookieTransport(Transport):
         return None
 
     async def get_logout_response(self, response: Response) -> Any:
-        response.delete_cookie(
-            self.cookie_name, path=self.cookie_path, domain=self.cookie_domain
+        response.set_cookie(
+            self.cookie_name,
+            '',
+            max_age=0,
+            path=self.cookie_path,
+            domain=self.cookie_domain,
+            secure=self.cookie_secure,
+            httponly=self.cookie_httponly,
+            samesite=self.cookie_samesite,
         )
 
     @staticmethod

--- a/fastapi_users/authentication/transport/cookie.py
+++ b/fastapi_users/authentication/transport/cookie.py
@@ -48,7 +48,7 @@ class CookieTransport(Transport):
     async def get_logout_response(self, response: Response) -> Any:
         response.set_cookie(
             self.cookie_name,
-            '',
+            "",
             max_age=0,
             path=self.cookie_path,
             domain=self.cookie_domain,


### PR DESCRIPTION
logout response is using starlette delete cookie. In starlette the samesite and secure attributes are not in the header but are needed to set the removed cookie client side. Implementing set_cookie with an empty cookie-value and a max_age of 0 will set a new expired cookie by the client.

related issue #846