### PR TITLE
chore(ref): Lift code into `else` after break in control flow

### DIFF
--- a/fastapi_users/jwt.py
+++ b/fastapi_users/jwt.py
@@ -9,9 +9,7 @@ JWT_ALGORITHM = "HS256"
 
 
 def _get_secret_value(secret: SecretType) -> str:
-    if isinstance(secret, SecretStr):
-        return secret.get_secret_value()
-    return secret
+    return secret.get_secret_value() if isinstance(secret, SecretStr) else secret
 
 
 def generate_jwt(

--- a/tests/test_authentication_strategy_redis.py
+++ b/tests/test_authentication_strategy_redis.py
@@ -22,9 +22,8 @@ class RedisMock:
             return None
 
     async def set(self, key: str, value: str, ex: Optional[int] = None):
-        expiration = None
-        if ex is not None:
-            expiration = int(datetime.now().timestamp() + ex)
+        expiration = int(datetime.now().timestamp() + ex) if ex is not None else None
+
         self.store[key] = (value, expiration)
 
     async def delete(self, key: str):


### PR DESCRIPTION
Where the body of an if statement ends with a break in the control flow, such as a continue, return or raise, the subsequent statements can be lifted into the else clause.