### PR TITLE
Generate setup.py file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
         codecov
     - name: Build and install it on system host
       run: |
-        flit build
+        flit build --setup-py
         flit install --deps none --python $(which python)
         python test_build.py
 
@@ -56,4 +56,4 @@ jobs:
         FLIT_USERNAME: ${{ secrets.FLIT_USERNAME }}
         FLIT_PASSWORD: ${{ secrets.FLIT_PASSWORD }}
       run: |
-        flit publish
+        flit publish --setup-py


### PR DESCRIPTION
As Python integration with FreeBSD ports is based on setup.py it would be so much easier to maintain it if that file was generated and uploaded. I am sure that FreeBSD is not the only OS that has this limitation, so potentially this will make porting easier for other operating systems, too.