### PR TITLE
Fix wrong import in MongoDB strategy example

### DIFF
--- a/docs/configuration/authentication/strategies/database.md
+++ b/docs/configuration/authentication/strategies/database.md
@@ -58,7 +58,7 @@ It is structured like this:
 
 ```py
 from fastapi import Depends
-from fastapi_users.authentication.db import AccessTokenDatabase, DatabaseStrategy
+from fastapi_users.authentication.strategy.db import AccessTokenDatabase, DatabaseStrategy
 
 from .models import AccessToken, UserCreate, UserDB
 


### PR DESCRIPTION
Thanks for this awesome library, very much appreciated!!

There seems to be a mistake in the import statement in the docs example on how to store access tokens in a MongoDB, which this PR fixes. 