### PR TITLE
Unique names for routes

### DIFF
--- a/fastapi_users/router/users.py
+++ b/fastapi_users/router/users.py
@@ -61,7 +61,7 @@ def get_users_router(
         "/me",
         response_model=user_model,
         dependencies=[Depends(get_current_active_user)],
-        name="users:current_user",
+        name="users:patch_current_user",
         responses={
             status.HTTP_401_UNAUTHORIZED: {
                 "description": "Missing token or inactive user.",
@@ -141,7 +141,7 @@ def get_users_router(
         "/{id:uuid}",
         response_model=user_model,
         dependencies=[Depends(get_current_superuser)],
-        name="users:user",
+        name="users:patch_user",
         responses={
             status.HTTP_401_UNAUTHORIZED: {
                 "description": "Missing token or inactive user.",
@@ -208,7 +208,7 @@ def get_users_router(
         status_code=status.HTTP_204_NO_CONTENT,
         response_class=Response,
         dependencies=[Depends(get_current_superuser)],
-        name="users:user",
+        name="users:delete_user",
         responses={
             status.HTTP_401_UNAUTHORIZED: {
                 "description": "Missing token or inactive user.",


### PR DESCRIPTION
Small fix to ensure that FastAPI-Users uses unique route names.

The why:

The pattern "[Using the path operation function name as the operationId](https://fastapi.tiangolo.com/advanced/path-operation-advanced-configuration/#using-the-path-operation-function-name-as-the-operationid)" simplifies the `operationId` attribute in the generated OpenAPI spec. Because there are duplicate names in FastAPI-Users (which this PR fixes), the generated schema deviates from the OpenAPI spec when this pattern is used.