### PR TITLE
CryptContext agnostic

### DIFF
--- a/fastapi_users/password.py
+++ b/fastapi_users/password.py
@@ -1,19 +1,31 @@
-from typing import Tuple
+from functools import lru_cache
+from typing import Tuple, Optional
 
 from passlib import pwd
 from passlib.context import CryptContext
 
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+@lru_cache()
+def get_crypt_context(**crypt_context_kwargs):
+    if crypt_context_kwargs:
+        if "schemes" not in crypt_context_kwargs:
+            crypt_context_kwargs["schemes"] = ["bcrypt"]
+        if "deprecated" not in crypt_context_kwargs:
+            crypt_context_kwargs["deprecated"] = ["auto"]
+        return CryptContext(**crypt_context_kwargs)
+    return CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 def verify_and_update_password(
-    plain_password: str, hashed_password: str
+    plain_password: str, hashed_password: str, crypt_context: Optional[CryptContext] = None
 ) -> Tuple[bool, str]:
-    return pwd_context.verify_and_update(plain_password, hashed_password)
+    crypt_context = crypt_context or get_crypt_context()
+    return crypt_context.verify_and_update(plain_password, hashed_password)
 
 
-def get_password_hash(password: str) -> str:
-    return pwd_context.hash(password)
+def get_password_hash(password: str, crypt_context: Optional[CryptContext] = None) -> str:
+    crypt_context = crypt_context or get_crypt_context()
+    return crypt_context.hash(password)
 
 
 def generate_password() -> str:


### PR DESCRIPTION
Refactor: pwd_context -> crypt_context; should be same name as the one used in parent package
Feature: `crypt_context_kwargs` in UserManager hierarchy.
Feature: Generate `passlib.CryptContext` from `crypt_context_kwargs` in UserManager hierarchy.

Reasoning:
The package should be `CryptContext` agnostic to accommodate all backend infrastructures. This is not a breaking change as the `CryptContext` generating function ensures that `schemes=["bcrypt"]`, `deprecated="auto"` if these kwargs are not defined in `crypt_context_kwargs`.