### PR TITLE
Update Documentation installation and fix new beanie install method

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,11 +8,22 @@ You can add **FastAPI Users** to your FastAPI project in a few easy steps. First
 pip install 'fastapi-users[sqlalchemy]'
 ```
 
+## With Redis support
+
+```sh
+pip install 'fastapi-users[redis]'
+```
+
 ## With Beanie support
 
 ```sh
-pip install 'fastapi-users[mongodb]'
+pip install 'fastapi-users[beanie]'
 ```
+
+## With OAuth2 support
+
+Information on installing with proper database support can be found in the [OAuth2](configuration/oauth.md) section.
+
 
 ---
 


### PR DESCRIPTION
As a `fastapi-user`, I was setting up `beanie` and found an issue where the 10.0 docs still point to the older style of package extra install. This PR changes that and adds the other optional extra packages to the install instructions. The `Redis` version didn't seem to be documented as well.  

Let me know your thoughts. 