### PR TITLE
Please consider uncapping `fastapi` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "fastapi >=0.65.2,<0.79.0",
+    "fastapi >=0.65.2",
     "passlib[bcrypt] ==1.7.4",
     "email-validator >=1.1.0,<1.3",
     "pyjwt[crypto] ==2.4.0",


### PR DESCRIPTION
`fastapi` is a project with a very frequent release cadence, and there's little risk of their upstream improvements breaking things for this project.  Users of this excellent user management tool should be able to update their `fastapi` install without having to also update this library, especially when there are significant breaking changes like the recent 9x-10x improvements that take time to reason about, test, and integrate.

I think this is a pretty safe change since the dependency window provided in the pyproject.toml indicates that there hasn't been a breaking change for this library from `fastapi` since 0.65.2. Another nice thing about uncapping upstream deps would be that this project would begin to get 'edge' tests for free, since the existing CI would pull the latest versions each time it runs. 

If needed, I'd be willing to submit another PR with a new or updated CI Build Action that tests the 'last known working version' too so that it's easier to diagnose if/when tests start to fail because of upstream changes.

Thanks for considering, and thanks for sharing this tool (and for the excellent docs).