### PR TITLE
Resolve CVE-2021-41945 in httpx dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,7 +105,7 @@ beanie = [
     "fastapi-users-db-beanie >=1.0.0",
 ]
 oauth = [
-    "httpx-oauth >=0.4,<0.7"
+    "httpx-oauth >=0.4,<=0.7"
 ]
 redis = [
     "redis >=4.3.3,<5.0.0",


### PR DESCRIPTION
Resolves [CVE-2021-41945](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-41945) in `httpx` by bumping the version requirement on `httpx-oauth` to be inclusive of `0.7`.