### PR TITLE
Cookie transport must return empty json and not `null` in `response.data` on login

### DIFF
--- a/fastapi_users/authentication/transport/cookie.py
+++ b/fastapi_users/authentication/transport/cookie.py
@@ -40,10 +40,11 @@ class CookieTransport(Transport):
             httponly=self.cookie_httponly,
             samesite=self.cookie_samesite,
         )
+        response.status_code = 204
 
         # We shouldn't return directly the response
         # so that FastAPI can terminate it properly
-        return None
+        return response
 
     async def get_logout_response(self, response: Response) -> Any:
         response.set_cookie(

--- a/fastapi_users/authentication/transport/cookie.py
+++ b/fastapi_users/authentication/transport/cookie.py
@@ -30,6 +30,7 @@ class CookieTransport(Transport):
         self.scheme = APIKeyCookie(name=self.cookie_name, auto_error=False)
 
     async def get_login_response(self, token: str, response: Response) -> Any:
+        response = Response(status_code=status.HTTP_204_NO_CONTENT)
         response.set_cookie(
             self.cookie_name,
             token,
@@ -40,10 +41,6 @@ class CookieTransport(Transport):
             httponly=self.cookie_httponly,
             samesite=self.cookie_samesite,
         )
-        response.status_code = 204
-
-        # We shouldn't return directly the response
-        # so that FastAPI can terminate it properly
         return response
 
     async def get_logout_response(self, response: Response) -> Any:
@@ -60,7 +57,7 @@ class CookieTransport(Transport):
 
     @staticmethod
     def get_openapi_login_responses_success() -> OpenAPIResponseType:
-        return {status.HTTP_200_OK: {"model": None}}
+        return {status.HTTP_204_NO_CONTENT: {"model": None}}
 
     @staticmethod
     def get_openapi_logout_responses_success() -> OpenAPIResponseType:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "fastapi >=0.79.0",
+    "fastapi >=0.65.2",
     "passlib[bcrypt] ==1.7.4",
     "email-validator >=1.1.0,<1.3",
     "pyjwt[crypto] ==2.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "fastapi >=0.65.2",
+    "fastapi >=0.79.0",
     "passlib[bcrypt] ==1.7.4",
     "email-validator >=1.1.0,<1.3",
     "pyjwt[crypto] ==2.4.0",

--- a/tests/test_authentication_transport_cookie.py
+++ b/tests/test_authentication_transport_cookie.py
@@ -38,10 +38,10 @@ async def test_get_login_response(cookie_transport: CookieTransport):
     secure = cookie_transport.cookie_secure
     httponly = cookie_transport.cookie_httponly
 
-    response = Response()
-    login_response = await cookie_transport.get_login_response("TOKEN", response)
+    response = await cookie_transport.get_login_response("TOKEN", Response())
 
-    assert login_response is None
+    assert isinstance(response, Response)
+    assert response.status_code == status.HTTP_204_NO_CONTENT
 
     cookies = [header for header in response.raw_headers if header[0] == b"set-cookie"]
     assert len(cookies) == 1
@@ -96,7 +96,7 @@ async def test_get_logout_response(cookie_transport: CookieTransport):
 @pytest.mark.openapi
 def test_get_openapi_login_responses_success(cookie_transport: CookieTransport):
     assert cookie_transport.get_openapi_login_responses_success() == {
-        status.HTTP_200_OK: {"model": None}
+        status.HTTP_204_NO_CONTENT: {"model": None}
     }
 
 


### PR DESCRIPTION
This causes issues when integrating the openapi schema into openapi-generator. Because the code generator expects the response to be a JSON, as it should be.