### PR TITLE
Refresh tokens, freshness pattern and scopes

### DIFF
--- a/fastapi_users/authentication/authenticator.py
+++ b/fastapi_users/authentication/authenticator.py
@@ -63,6 +63,7 @@ class Authenticator:
         active: bool = False,
         verified: bool = False,
         superuser: bool = False,
+        fresh: bool = False,
         get_enabled_backends: Optional[EnabledBackendsDependency] = None,
     ):
         """
@@ -96,6 +97,7 @@ class Authenticator:
                 active=active,
                 verified=verified,
                 superuser=superuser,
+                fresh=fresh,
                 **kwargs,
             )
             return token_data.user, token
@@ -108,6 +110,7 @@ class Authenticator:
         active: bool = False,
         verified: bool = False,
         superuser: bool = False,
+        fresh: bool = False,
         get_enabled_backends: Optional[EnabledBackendsDependency] = None,
     ):
         """
@@ -141,6 +144,7 @@ class Authenticator:
                 active=active,
                 verified=verified,
                 superuser=superuser,
+                fresh=fresh,
                 **kwargs,
             )
             if token_data:
@@ -155,6 +159,7 @@ class Authenticator:
         active: bool = False,
         verified: bool = False,
         superuser: bool = False,
+        fresh: bool = False,
         get_enabled_backends: Optional[EnabledBackendsDependency] = None,
     ):
         """
@@ -188,6 +193,7 @@ class Authenticator:
                 active=active,
                 verified=verified,
                 superuser=superuser,
+                fresh=fresh,
                 **kwargs,
             )
             return token_data
@@ -202,6 +208,7 @@ class Authenticator:
         active: bool = False,
         verified: bool = False,
         superuser: bool = False,
+        fresh: bool = False,
         **kwargs,
     ) -> Tuple[Optional[UserTokenData[models.UP, models.ID]], Optional[str]]:
         token_data: Optional[UserTokenData[models.UP, models.ID]] = None
@@ -228,10 +235,9 @@ class Authenticator:
                     status_code = status.HTTP_401_UNAUTHORIZED
                     token_data = None
                 elif (
-                    verified
-                    and not token_data.user.is_verified
-                    or superuser
-                    and not token_data.user.is_superuser
+                    (verified and not token_data.user.is_verified)
+                    or (superuser and not token_data.user.is_superuser)
+                    or (fresh and not token_data.fresh)
                 ):
                     token_data = None
         if not token_data and not optional:

--- a/fastapi_users/authentication/backend.py
+++ b/fastapi_users/authentication/backend.py
@@ -1,4 +1,5 @@
-from typing import Any, Generic
+from datetime import datetime
+from typing import Any, Generic, Optional, Set
 
 from fastapi import Response
 
@@ -7,6 +8,7 @@ from fastapi_users.authentication.strategy import (
     Strategy,
     StrategyDestroyNotSupportedError,
 )
+from fastapi_users.authentication.token import UserTokenData
 from fastapi_users.authentication.transport import (
     LoginT,
     LogoutT,
@@ -14,6 +16,7 @@ from fastapi_users.authentication.transport import (
     TransportLogoutNotSupportedError,
     TransportTokenResponse,
 )
+from fastapi_users.scopes import SystemScope
 from fastapi_users.types import DependencyCallable
 
 
@@ -36,25 +39,57 @@ class AuthenticationBackend(Generic[LoginT, LogoutT]):
         self,
         name: str,
         transport: Transport[LoginT, LogoutT],
+        get_strategy: DependencyCallable[Strategy],
+        access_token_lifetime_seconds: Optional[int] = 3600,
+        refresh_token_enabled: bool = False,
+        refresh_token_lifetime_seconds: Optional[int] = 86400,
     ):
         self.name = name
         self.transport = transport
         self.get_strategy = get_strategy
+        self.access_token_lifetime_seconds = access_token_lifetime_seconds
+        self.refresh_token_enabled = refresh_token_enabled
+        self.refresh_token_lifetime_seconds = refresh_token_lifetime_seconds
 
     async def login(
         self,
-        strategy: Strategy[models.UP, models.ID],
+        strategy: Strategy,
         user: models.UserProtocol[Any],
         response: Response,
+        last_authenticated: Optional[datetime] = None,
     ) -> Optional[LoginT]:
-        token_response = TransportTokenResponse(
-            access_token=await strategy.write_token(user)
+        scopes: Set[str] = set()
+        if user.is_active:
+            scopes.add(SystemScope.USER)
+        if user.is_verified:
+            scopes.add(SystemScope.VERIFIED)
+        if user.is_superuser:
+            scopes.add(SystemScope.SUPERUSER)
+
+        access_token_data = UserTokenData.issue_now(
+            user,
+            self.access_token_lifetime_seconds,
+            last_authenticated,
+            scopes=scopes,
         )
+        token_response = TransportTokenResponse(
+            access_token=await strategy.write_token(access_token_data)
+        )
+        if self.refresh_token_enabled:
+            refresh_token_data = UserTokenData.issue_now(
+                user,
+                self.refresh_token_lifetime_seconds,
+                last_authenticated,
+                scopes={SystemScope.REFRESH},
+            )
+            token_response.refresh_token = await strategy.write_token(
+                refresh_token_data
+            )
         return await self.transport.get_login_response(token_response, response)
 
     async def logout(
         self,
-        strategy: Strategy[models.UP, models.ID],
+        strategy: Strategy,
         user: models.UserProtocol[Any],
         token: str,
         response: Response,

--- a/fastapi_users/authentication/strategy/base.py
+++ b/fastapi_users/authentication/strategy/base.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Generic, Optional
+from typing import Any, Dict, Generic, Optional
 
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol  # pragma: no cover
@@ -7,6 +7,7 @@ else:
     from typing import Protocol  # pragma: no cover
 
 from fastapi_users import models
+from fastapi_users.authentication.token import UserTokenData
 from fastapi_users.manager import BaseUserManager
 
 
@@ -14,14 +15,23 @@ class StrategyDestroyNotSupportedError(Exception):
     pass
 
 
-class Strategy(Protocol, Generic[models.UP, models.ID]):
+class Strategy(Protocol):
     async def read_token(
-        self, token: Optional[str], user_manager: BaseUserManager[models.UP, models.ID]
-    ) -> Optional[models.UP]:
+        self,
+        token: Optional[str],
+        user_manager: BaseUserManager[models.UP, models.ID],
+    ) -> Optional[UserTokenData[models.UP, models.ID]]:
         ...  # pragma: no cover
 
-    async def write_token(self, user: models.UP) -> str:
+    async def write_token(
+        self,
+        token_data: UserTokenData[models.UserProtocol[Any], Any],
+    ) -> str:
         ...  # pragma: no cover
 
-    async def destroy_token(self, token: str, user: models.UP) -> None:
+    async def destroy_token(
+        self,
+        token: str,
+        user: models.UserProtocol[Any],
+    ) -> None:
         ...  # pragma: no cover

--- a/fastapi_users/authentication/strategy/db/models.py
+++ b/fastapi_users/authentication/strategy/db/models.py
@@ -1,6 +1,6 @@
 import sys
 from datetime import datetime
-from typing import TypeVar
+from typing import Optional, TypeVar
 
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol  # pragma: no cover
@@ -16,6 +16,9 @@ class AccessTokenProtocol(Protocol[models.ID]):
     token: str
     user_id: models.ID
     created_at: datetime
+    expires_at: Optional[datetime]
+    last_authenticated: datetime
+    scopes: str
 
     def __init__(self, *args, **kwargs) -> None:
         ...  # pragma: no cover

--- a/fastapi_users/authentication/token.py
+++ b/fastapi_users/authentication/token.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any, Generic, Iterable, Optional, Set
+
+from pydantic import BaseModel, Field, validator
+
+from fastapi_users import models
+from fastapi_users.manager import BaseUserManager
+from fastapi_users.scopes import Scope, SystemScope
+
+
+class TokenData(BaseModel):
+    user_id: Any
+    created_at: datetime
+    expires_at: Optional[datetime]
+    last_authenticated: datetime
+    scopes: Set[Scope]
+
+    @validator("scopes")
+    def _validate_scopes(cls, v: Set[Scope]) -> Set[Scope]:
+        def _validate_scope(scope: Scope) -> Scope:
+            if isinstance(scope, SystemScope):
+                return scope
+            # As we are going to use these for OAuth 2.0 tokens,
+            # all scopes should be valid OAuth 2.0 scopes - see
+            # https://www.rfc-editor.org/rfc/rfc6749#section-3.3
+            assert re.match(r"^[!#-\[\]-~]+$", scope)
+            try:
+                return SystemScope(scope)
+            except ValueError:
+                return scope
+
+        return set(_validate_scope(x) for x in v)
+
+    @property
+    def scope(self) -> str:
+        return " ".join(str(x) for x in self.scopes)
+
+    @property
+    def fresh(self) -> bool:
+        return self.created_at == self.last_authenticated
+
+    @property
+    def expired(self) -> bool:
+        if self.expires_at is None:
+            return False
+        return self.expires_at <= datetime.now(timezone.utc)
+
+    @property
+    def time_to_expiry(self) -> Optional[timedelta]:
+        if self.expires_at is None:
+            return None
+        return self.expires_at - datetime.now(timezone.utc)
+
+    async def lookup_user(
+        self, user_manager: BaseUserManager[models.UP, models.ID]
+    ) -> UserTokenData[models.UP, models.ID]:
+        user_id = user_manager.parse_id(self.user_id)
+        return UserTokenData(
+            user_id=user_id,
+            **self.dict(exclude={"user_id"}),
+            user=await user_manager.get(user_id),
+        )
+
+
+class UserTokenData(TokenData, Generic[models.UP, models.ID]):
+    user: models.UP = Field(..., exclude=True)
+
+    @classmethod
+    def issue_now(
+        cls,
+        user: models.UserProtocol[models.ID],
+        lifetime_seconds: Optional[int] = None,
+        last_authenticated: Optional[datetime] = None,
+        scopes: Optional[Iterable[Scope]] = None,
+    ) -> UserTokenData[models.UP, models.ID]:
+
+        scopes = scopes or set()
+
+        now = datetime.now(timezone.utc)
+
+        if lifetime_seconds is None:
+            expires_at = None
+        else:
+            expires_at = now + timedelta(seconds=lifetime_seconds)
+
+        return cls(
+            user_id=user.id,
+            created_at=now,
+            expires_at=expires_at,
+            last_authenticated=last_authenticated or now,
+            scopes=set(scopes),
+            user=user,
+        )
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/fastapi_users/authentication/transport/__init__.py
+++ b/fastapi_users/authentication/transport/__init__.py
@@ -1,6 +1,9 @@
 from fastapi_users.authentication.transport.base import (
+    LoginT,
+    LogoutT,
     Transport,
     TransportLogoutNotSupportedError,
+    TransportTokenResponse,
 )
 from fastapi_users.authentication.transport.bearer import BearerTransport
 from fastapi_users.authentication.transport.cookie import CookieTransport
@@ -9,5 +12,8 @@ __all__ = [
     "BearerTransport",
     "CookieTransport",
     "Transport",
+    "TransportTokenResponse",
     "TransportLogoutNotSupportedError",
+    "LoginT",
+    "LogoutT",
 ]

--- a/fastapi_users/authentication/transport/base.py
+++ b/fastapi_users/authentication/transport/base.py
@@ -1,5 +1,7 @@
 import sys
-from typing import Any
+from typing import Optional, Type, TypeVar
+
+from pydantic import BaseModel
 
 if sys.version_info < (3, 8):
     from typing_extensions import Protocol  # pragma: no cover
@@ -16,13 +18,26 @@ class TransportLogoutNotSupportedError(Exception):
     pass
 
 
-class Transport(Protocol):
+class TransportTokenResponse(BaseModel):
+    access_token: str
+    refresh_token: Optional[str] = None
+
+
+LoginT = TypeVar("LoginT")
+LogoutT = TypeVar("LogoutT")
+
+
+class Transport(Protocol[LoginT, LogoutT]):
+    login_response_model: Optional[Type[LoginT]] = None
+    logout_response_model: Optional[Type[LogoutT]] = None
     scheme: SecurityBase
 
-    async def get_login_response(self, token: str, response: Response) -> Any:
+    async def get_login_response(
+        self, token: TransportTokenResponse, response: Response
+    ) -> LoginT:
         ...  # pragma: no cover
 
-    async def get_logout_response(self, response: Response) -> Any:
+    async def get_logout_response(self, response: Response) -> LogoutT:
         ...  # pragma: no cover
 
     @staticmethod

--- a/fastapi_users/authentication/transport/cookie.py
+++ b/fastapi_users/authentication/transport/cookie.py
@@ -1,13 +1,18 @@
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import Response, status
 from fastapi.security import APIKeyCookie
 
-from fastapi_users.authentication.transport.base import Transport
+from fastapi_users.authentication.transport.base import (
+    Transport,
+    TransportTokenResponse,
+)
 from fastapi_users.openapi import OpenAPIResponseType
 
 
-class CookieTransport(Transport):
+class CookieTransport(Transport[None, None]):
+    login_response_model = None
+    logout_response_model = None
     scheme: APIKeyCookie
 
     def __init__(
@@ -29,10 +34,17 @@ class CookieTransport(Transport):
         self.cookie_samesite = cookie_samesite
         self.scheme = APIKeyCookie(name=self.cookie_name, auto_error=False)
 
-    async def get_login_response(self, token: str, response: Response) -> Any:
+    async def get_login_response(
+        self, token: TransportTokenResponse, response: Response
+    ) -> None:
+        if token.refresh_token:
+            raise NotImplementedError(
+                "Refresh tokens not yet supported by cookie transport"
+            )
+
         response.set_cookie(
             self.cookie_name,
-            token,
+            token.access_token,
             max_age=self.cookie_max_age,
             path=self.cookie_path,
             domain=self.cookie_domain,
@@ -45,7 +57,7 @@ class CookieTransport(Transport):
         # so that FastAPI can terminate it properly
         return None
 
-    async def get_logout_response(self, response: Response) -> Any:
+    async def get_logout_response(self, response: Response) -> None:
         response.set_cookie(
             self.cookie_name,
             "",

--- a/fastapi_users/router/__init__.py
+++ b/fastapi_users/router/__init__.py
@@ -1,5 +1,6 @@
 from fastapi_users.router.auth import get_auth_router
 from fastapi_users.router.common import ErrorCode
+from fastapi_users.router.refresh import get_refresh_router
 from fastapi_users.router.register import get_register_router
 from fastapi_users.router.reset import get_reset_password_router
 from fastapi_users.router.users import get_users_router
@@ -8,6 +9,7 @@ from fastapi_users.router.verify import get_verify_router
 __all__ = [
     "ErrorCode",
     "get_auth_router",
+    "get_refresh_router",
     "get_register_router",
     "get_reset_password_router",
     "get_users_router",

--- a/fastapi_users/router/auth.py
+++ b/fastapi_users/router/auth.py
@@ -1,4 +1,4 @@
-from typing import Tuple
+from typing import Any, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
@@ -11,7 +11,7 @@ from fastapi_users.router.common import ErrorCode, ErrorModel
 
 
 def get_auth_router(
-    backend: AuthenticationBackend,
+    backend: AuthenticationBackend[Any, Any],
     get_user_manager: UserManagerDependency[models.UP, models.ID],
     authenticator: Authenticator,
     requires_verification: bool = False,
@@ -46,9 +46,11 @@ def get_auth_router(
     @router.post(
         "/login",
         name=f"auth:{backend.name}.login",
+        response_model=backend.transport.login_response_model,
+        response_model_exclude_none=True,
         responses=login_responses,
     )
-    async def login(
+    async def login(  # type: ignore
         response: Response,
         credentials: OAuth2PasswordRequestForm = Depends(),
         user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
@@ -78,9 +80,12 @@ def get_auth_router(
     }
 
     @router.post(
-        "/logout", name=f"auth:{backend.name}.logout", responses=logout_responses
+        "/logout",
+        name=f"auth:{backend.name}.logout",
+        response_model=backend.transport.logout_response_model,
+        responses=logout_responses,
     )
-    async def logout(
+    async def logout(  # type: ignore
         response: Response,
         user_token: Tuple[models.UP, str] = Depends(get_current_user_token),
         strategy: Strategy[models.UP, models.ID] = Depends(backend.get_strategy),

--- a/fastapi_users/router/auth.py
+++ b/fastapi_users/router/auth.py
@@ -1,4 +1,4 @@
-from typing import Any, Tuple
+from typing import Optional, Tuple
 
 from fastapi import APIRouter, Depends, HTTPException, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
@@ -11,7 +11,7 @@ from fastapi_users.router.common import ErrorCode, ErrorModel
 
 
 def get_auth_router(
-    backend: AuthenticationBackend[Any, Any],
+    backend: AuthenticationBackend[models.UP, models.ID],
     get_user_manager: UserManagerDependency[models.UP, models.ID],
     authenticator: Authenticator,
     requires_verification: bool = False,
@@ -54,7 +54,7 @@ def get_auth_router(
         response: Response,
         credentials: OAuth2PasswordRequestForm = Depends(),
         user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
-        strategy: Strategy[models.UP, models.ID] = Depends(backend.get_strategy),
+        strategy: Strategy = Depends(backend.get_strategy),
     ):
         user = await user_manager.authenticate(credentials)
 
@@ -88,7 +88,7 @@ def get_auth_router(
     async def logout(  # type: ignore
         response: Response,
         user_token: Tuple[models.UP, str] = Depends(get_current_user_token),
-        strategy: Strategy[models.UP, models.ID] = Depends(backend.get_strategy),
+        strategy: Strategy = Depends(backend.get_strategy),
     ):
         user, token = user_token
         return await backend.logout(strategy, user, token, response)

--- a/fastapi_users/router/oauth.py
+++ b/fastapi_users/router/oauth.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, Type
+from typing import Dict, List, Tuple, Type
 
 import jwt
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from fastapi_users import models, schemas
 from fastapi_users.authentication import AuthenticationBackend, Authenticator, Strategy
+from fastapi_users.authentication.token import UserTokenData
 from fastapi_users.exceptions import UserAlreadyExists
 from fastapi_users.jwt import SecretType, decode_jwt, generate_jwt
 from fastapi_users.manager import BaseUserManager, UserManagerDependency
@@ -29,7 +30,7 @@ def generate_state_token(
 
 def get_oauth_router(
     oauth_client: BaseOAuth2,
-    backend: AuthenticationBackend[Any, Any],
+    backend: AuthenticationBackend,
     get_user_manager: UserManagerDependency[models.UP, models.ID],
     state_secret: SecretType,
     redirect_url: str = None,
@@ -106,7 +107,7 @@ def get_oauth_router(
             oauth2_authorize_callback
         ),
         user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
-        strategy: Strategy[models.UP, models.ID] = Depends(backend.get_strategy),
+        strategy: Strategy = Depends(backend.get_strategy),
     ):
         token, state = access_token_state
         account_id, account_email = await oauth_client.get_id_email(

--- a/fastapi_users/router/oauth.py
+++ b/fastapi_users/router/oauth.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Tuple, Type
+from typing import Any, Dict, List, Tuple, Type
 
 import jwt
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
@@ -29,7 +29,7 @@ def generate_state_token(
 
 def get_oauth_router(
     oauth_client: BaseOAuth2,
-    backend: AuthenticationBackend,
+    backend: AuthenticationBackend[Any, Any],
     get_user_manager: UserManagerDependency[models.UP, models.ID],
     state_secret: SecretType,
     redirect_url: str = None,
@@ -77,6 +77,8 @@ def get_oauth_router(
         "/callback",
         name=callback_route_name,
         description="The response varies based on the authentication backend used.",
+        response_model=backend.transport.login_response_model,
+        response_model_exclude_none=True,
         responses={
             status.HTTP_400_BAD_REQUEST: {
                 "model": ErrorModel,

--- a/fastapi_users/router/refresh.py
+++ b/fastapi_users/router/refresh.py
@@ -1,0 +1,91 @@
+from fastapi import APIRouter, Depends, Form, HTTPException, Response, status
+
+from fastapi_users import models
+from fastapi_users.authentication import AuthenticationBackend, Strategy
+from fastapi_users.manager import BaseUserManager, UserManagerDependency
+from fastapi_users.openapi import OpenAPIResponseType
+from fastapi_users.router.common import ErrorCode, ErrorModel
+from fastapi_users.scopes import SystemScope
+
+
+class OAuth2RefreshTokenForm(object):
+    def __init__(
+        self,
+        grant_type: str = Form(
+            default="refresh_token", regex="refresh_token", example="refresh_token"
+        ),
+        refresh_token: str = Form(...),
+        scope: str = Form(""),
+    ):
+        self.grant_type = grant_type
+        self.refresh_token = refresh_token
+        self.scopes = scope.split()
+
+
+def get_refresh_router(
+    backend: AuthenticationBackend[models.UP, models.ID],
+    get_user_manager: UserManagerDependency[models.UP, models.ID],
+) -> APIRouter:
+    """Generate a router with login/logout routes for an authentication backend."""
+    router = APIRouter()
+
+    login_responses: OpenAPIResponseType = {
+        status.HTTP_400_BAD_REQUEST: {
+            "model": ErrorModel,
+            "content": {
+                "application/json": {
+                    "examples": {
+                        ErrorCode.LOGIN_BAD_CREDENTIALS: {
+                            "summary": "Bad credentials or the user is inactive.",
+                            "value": {"detail": ErrorCode.LOGIN_BAD_CREDENTIALS},
+                        },
+                        ErrorCode.LOGIN_USER_NOT_VERIFIED: {
+                            "summary": "The user is not verified.",
+                            "value": {"detail": ErrorCode.LOGIN_USER_NOT_VERIFIED},
+                        },
+                    }
+                }
+            },
+        },
+        **backend.transport.get_openapi_login_responses_success(),
+    }
+
+    @router.post(
+        "/refresh",
+        name=f"auth:{backend.name}.refresh",
+        responses=login_responses,
+        response_model=backend.transport.login_response_model,
+        response_model_exclude_none=True,
+    )
+    async def refresh(  # type: ignore
+        response: Response,
+        form_data: OAuth2RefreshTokenForm = Depends(),
+        user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
+        strategy: Strategy = Depends(backend.get_strategy),
+    ):
+        if not backend.refresh_token_enabled:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="refresh_tokens_not_allowed",
+            )
+
+        token_data = await strategy.read_token(form_data.refresh_token, user_manager)
+        if token_data:
+            if (
+                token_data.user
+                and SystemScope.REFRESH in token_data.scopes
+                and not token_data.expired
+            ):
+                return await backend.login(
+                    strategy,
+                    token_data.user,
+                    response,
+                    token_data.last_authenticated,
+                )
+
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="invalid_grant",
+        )
+
+    return router

--- a/fastapi_users/router/users.py
+++ b/fastapi_users/router/users.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 
 from fastapi_users import exceptions, models, schemas
 from fastapi_users.authentication import Authenticator
+from fastapi_users.authentication.token import UserTokenData
 from fastapi_users.manager import BaseUserManager, UserManagerDependency
 from fastapi_users.router.common import ErrorCode, ErrorModel
 

--- a/fastapi_users/scopes.py
+++ b/fastapi_users/scopes.py
@@ -1,0 +1,16 @@
+from enum import Enum
+from typing import Union
+
+
+class SystemScope(str, Enum):
+    USER = "fastapi-users:user"
+    SUPERUSER = "fastapi-users:superuser"
+    VERIFIED = "fastapi-users:verified"
+    REFRESH = "fastapi-users:refresh"
+
+    def __str__(self) -> str:
+        return self.value
+
+
+UserDefinedScope = str
+Scope = Union[SystemScope, UserDefinedScope]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ dev = [
     "asgi_lifespan",
     "uvicorn",
     "types-redis",
+    "pytest-freezegun",
 ]
 sqlalchemy = [
     "fastapi-users-db-sqlalchemy >=4.0.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ from pytest_mock import MockerFixture
 from fastapi_users import exceptions, models, schemas
 from fastapi_users.authentication import AuthenticationBackend, BearerTransport
 from fastapi_users.authentication.strategy import Strategy
+from fastapi_users.authentication.transport.bearer import BearerResponse
 from fastapi_users.db import BaseUserDatabase
 from fastapi_users.jwt import SecretType
 from fastapi_users.manager import BaseUserManager, UUIDIDMixin
@@ -523,7 +524,8 @@ class MockTransport(BearerTransport):
         return {}
 
 
-class MockStrategy(Strategy[UserModel, IDType]):
+MockBackend = AuthenticationBackend[BearerResponse, None]
+
     async def read_token(
         self, token: Optional[str], user_manager: BaseUserManager[UserModel, IDType]
     ) -> Optional[UserModel]:

--- a/tests/test_authentication_authenticator.py
+++ b/tests/test_authentication_authenticator.py
@@ -1,4 +1,4 @@
-from typing import AsyncGenerator, Generic, List, Optional, Sequence
+from typing import AsyncGenerator, Generic, List, Optional, Sequence, Tuple
 
 import httpx
 import pytest
@@ -9,10 +9,11 @@ from fastapi_users import models
 from fastapi_users.authentication import AuthenticationBackend, Authenticator
 from fastapi_users.authentication.authenticator import DuplicateBackendNamesError
 from fastapi_users.authentication.strategy import Strategy
+from fastapi_users.authentication.token import TokenData, UserTokenData
 from fastapi_users.authentication.transport import Transport
 from fastapi_users.manager import BaseUserManager
 from fastapi_users.types import DependencyCallable
-from tests.conftest import User, UserModel
+from tests.conftest import IDType, User, UserModel
 
 
 class MockSecurityScheme(SecurityBase):
@@ -29,19 +30,23 @@ class MockTransport(Transport):
 
 class NoneStrategy(Strategy):
     async def read_token(
-        self, token: Optional[str], user_manager: BaseUserManager[models.UP, models.ID]
-    ) -> Optional[models.UP]:
+        self,
+        token: Optional[str],
+        user_manager: BaseUserManager[models.UP, models.ID],
+    ) -> Optional[UserTokenData[models.UP, models.ID]]:
         return None
 
 
-class UserStrategy(Strategy, Generic[models.UP]):
-    def __init__(self, user: models.UP):
-        self.user = user
+class UserStrategy(Strategy, Generic[models.UP, models.ID]):
+    def __init__(self, token_data: UserTokenData[models.UP, models.ID]):
+        self.token_data = token_data
 
     async def read_token(
-        self, token: Optional[str], user_manager: BaseUserManager[models.UP, models.ID]
-    ) -> Optional[models.UP]:
-        return self.user
+        self,
+        token: Optional[str],
+        user_manager: BaseUserManager[models.UP, models.ID],
+    ) -> Optional[UserTokenData[models.UP, models.ID]]:
+        return self.token_data
 
 
 @pytest.fixture
@@ -55,20 +60,32 @@ def get_backend_none():
 
 
 @pytest.fixture
-def get_backend_user(user: UserModel):
+def get_backend_user(token_data: UserTokenData[UserModel, IDType]):
     def _get_backend_user(name: str = "user"):
         return AuthenticationBackend(
             name=name,
             transport=MockTransport(),
-            get_strategy=lambda: UserStrategy(user),
+            get_strategy=lambda: UserStrategy(token_data),
         )
 
     return _get_backend_user
 
 
+@pytest.fixture(params=[False])
+def require_active(request: pytest.FixtureRequest) -> bool:
+    return getattr(request, "param")
+
+
+@pytest.fixture(params=[False])
+def require_superuser(request: pytest.FixtureRequest) -> bool:
+    return getattr(request, "param")
+
+
 @pytest.fixture
 @pytest.mark.asyncio
-def get_test_auth_client(get_user_manager, get_test_client):
+def get_test_auth_client(
+    get_user_manager, get_test_client, require_active: bool, require_superuser: bool
+):
     async def _get_test_auth_client(
         backends: List[AuthenticationBackend],
         get_enabled_backends: Optional[
@@ -81,32 +98,40 @@ def get_test_auth_client(get_user_manager, get_test_client):
         @app.get("/test-current-user", response_model=User)
         def test_current_user(
             user: UserModel = Depends(
-                authenticator.current_user(get_enabled_backends=get_enabled_backends)
-            ),
-        ):
-            return user
-
-        @app.get("/test-current-active-user", response_model=User)
-        def test_current_active_user(
-            user: UserModel = Depends(
                 authenticator.current_user(
-                    active=True, get_enabled_backends=get_enabled_backends
-                )
-            ),
-        ):
-            return user
-
-        @app.get("/test-current-superuser", response_model=User)
-        def test_current_superuser(
-            user: UserModel = Depends(
-                authenticator.current_user(
-                    active=True,
-                    superuser=True,
+                    active=require_active,
+                    superuser=require_superuser,
                     get_enabled_backends=get_enabled_backends,
                 )
             ),
         ):
             return user
+
+        @app.get("/test-current-user-token", response_model=User)
+        def test_current_token(
+            user_token: Tuple[UserModel, str] = Depends(
+                authenticator.current_user_token(
+                    active=require_active,
+                    superuser=require_superuser,
+                    get_enabled_backends=get_enabled_backends,
+                )
+            ),
+        ):
+            user, token = user_token
+            assert token
+            return user
+
+        @app.get("/test-current-token", response_model=TokenData)
+        def test_current_token(
+            token_data: UserTokenData[UserModel, IDType] = Depends(
+                authenticator.current_token(
+                    active=require_active,
+                    superuser=require_superuser,
+                    get_enabled_backends=get_enabled_backends,
+                )
+            ),
+        ):
+            return TokenData(**token_data.dict())
 
         async for client in get_test_client(app):
             yield client
@@ -116,26 +141,58 @@ def get_test_auth_client(get_user_manager, get_test_client):
 
 @pytest.mark.authentication
 @pytest.mark.asyncio
-async def test_authenticator(get_test_auth_client, get_backend_none, get_backend_user):
+@pytest.mark.parametrize("require_active", [False], indirect=True)
+@pytest.mark.parametrize("require_superuser", [False], indirect=True)
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/test-current-user",
+        "/test-current-user-token",
+        "/test-current-token",
+    ],
+)
+async def test_authenticator(
+    get_test_auth_client, get_backend_none, get_backend_user, path: str
+):
     async for client in get_test_auth_client([get_backend_none(), get_backend_user()]):
-        response = await client.get("/test-current-user")
+        response = await client.get(path)
         assert response.status_code == status.HTTP_200_OK
 
 
 @pytest.mark.authentication
 @pytest.mark.asyncio
-async def test_authenticator_none(get_test_auth_client, get_backend_none):
+@pytest.mark.parametrize("require_active", [False], indirect=True)
+@pytest.mark.parametrize("require_superuser", [False], indirect=True)
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/test-current-user",
+        "/test-current-user-token",
+        "/test-current-token",
+    ],
+)
+async def test_authenticator_none(get_test_auth_client, get_backend_none, path: str):
     async for client in get_test_auth_client(
         [get_backend_none(), get_backend_none(name="none-bis")]
     ):
-        response = await client.get("/test-current-user")
+        response = await client.get(path)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 @pytest.mark.authentication
 @pytest.mark.asyncio
+@pytest.mark.parametrize("require_active", [False], indirect=True)
+@pytest.mark.parametrize("require_superuser", [False], indirect=True)
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/test-current-user",
+        "/test-current-user-token",
+        "/test-current-token",
+    ],
+)
 async def test_authenticator_none_enabled(
-    get_test_auth_client, get_backend_none, get_backend_user
+    get_test_auth_client, get_backend_none, get_backend_user, path: str
 ):
     backend_none = get_backend_none()
     backend_user = get_backend_user()
@@ -146,7 +203,7 @@ async def test_authenticator_none_enabled(
     async for client in get_test_auth_client(
         [backend_none, backend_user], get_enabled_backends
     ):
-        response = await client.get("/test-current-user")
+        response = await client.get(path)
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 

--- a/tests/test_authentication_strategy_db.py
+++ b/tests/test_authentication_strategy_db.py
@@ -10,7 +10,8 @@ from fastapi_users.authentication.strategy import (
     AccessTokenProtocol,
     DatabaseStrategy,
 )
-from tests.conftest import IDType, UserModel
+from fastapi_users.authentication.token import UserTokenData
+from tests.conftest import IDType, UserManager, UserModel
 
 
 @dataclasses.dataclass
@@ -21,6 +22,11 @@ class AccessTokenModel(AccessTokenProtocol[IDType]):
     created_at: datetime = dataclasses.field(
         default_factory=lambda: datetime.now(timezone.utc)
     )
+    expires_at: Optional[datetime] = None
+    last_authenticated: datetime = dataclasses.field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    scopes: str = ""
 
 
 class AccessTokenDatabaseMock(AccessTokenDatabase[AccessTokenModel]):
@@ -60,6 +66,18 @@ class AccessTokenDatabaseMock(AccessTokenDatabase[AccessTokenModel]):
             pass
 
 
+def assert_valid_token_model(
+    access_token: Optional[AccessTokenModel],
+    token_data: UserTokenData[UserModel, IDType],
+):
+    assert access_token is not None
+    assert access_token.user_id == token_data.user.id
+    assert access_token.created_at == token_data.created_at
+    assert access_token.expires_at == token_data.expires_at
+    assert access_token.last_authenticated == token_data.last_authenticated
+    assert access_token.scopes == token_data.scope
+
+
 @pytest.fixture
 def access_token_database() -> AccessTokenDatabaseMock:
     return AccessTokenDatabaseMock()
@@ -67,7 +85,7 @@ def access_token_database() -> AccessTokenDatabaseMock:
 
 @pytest.fixture
 def database_strategy(access_token_database: AccessTokenDatabaseMock):
-    return DatabaseStrategy(access_token_database, 3600)
+    return DatabaseStrategy(access_token_database)
 
 
 @pytest.mark.authentication
@@ -75,8 +93,8 @@ class TestReadToken:
     @pytest.mark.asyncio
     async def test_missing_token(
         self,
-        database_strategy: DatabaseStrategy[UserModel, IDType, AccessTokenModel],
-        user_manager,
+        database_strategy: DatabaseStrategy[AccessTokenModel],
+        user_manager: UserManager,
     ):
         authenticated_user = await database_strategy.read_token(None, user_manager)
         assert authenticated_user is None
@@ -84,8 +102,8 @@ class TestReadToken:
     @pytest.mark.asyncio
     async def test_invalid_token(
         self,
-        database_strategy: DatabaseStrategy[UserModel, IDType, AccessTokenModel],
-        user_manager,
+        database_strategy: DatabaseStrategy[AccessTokenModel],
+        user_manager: UserManager,
     ):
         authenticated_user = await database_strategy.read_token("TOKEN", user_manager)
         assert authenticated_user is None
@@ -93,51 +111,80 @@ class TestReadToken:
     @pytest.mark.asyncio
     async def test_valid_token_not_existing_user(
         self,
-        database_strategy: DatabaseStrategy[UserModel, IDType, AccessTokenModel],
+        database_strategy: DatabaseStrategy[AccessTokenModel],
         access_token_database: AccessTokenDatabaseMock,
-        user_manager,
+        user_manager: UserManager,
+        token_data: UserTokenData[UserModel, IDType],
     ):
         await access_token_database.create(
             {
                 "token": "TOKEN",
                 "user_id": uuid.UUID("d35d213e-f3d8-4f08-954a-7e0d1bea286f"),
+                "scopes": token_data.scope,
+                **token_data.dict(exclude={"user_id", "user", "scopes"}),
             }
         )
-        authenticated_user = await database_strategy.read_token("TOKEN", user_manager)
-        assert authenticated_user is None
+        access_token = await database_strategy.read_token("TOKEN", user_manager)
+        assert access_token is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("token_expired", [True])
+    async def test_expired_token(
+        self,
+        database_strategy: DatabaseStrategy[AccessTokenModel],
+        access_token_database: AccessTokenDatabaseMock,
+        user_manager: UserManager,
+        token_data: UserTokenData[UserModel, IDType],
+    ):
+        await access_token_database.create(
+            {
+                "token": "TOKEN",
+                "user_id": token_data.user.id,
+                "scopes": token_data.scope,
+                **token_data.dict(exclude={"user_id", "user", "scopes"}),
+            }
+        )
+        access_token = await database_strategy.read_token("TOKEN", user_manager)
+        assert access_token is None
 
     @pytest.mark.asyncio
     async def test_valid_token(
         self,
-        database_strategy: DatabaseStrategy[UserModel, IDType, AccessTokenModel],
+        database_strategy: DatabaseStrategy[AccessTokenModel],
         access_token_database: AccessTokenDatabaseMock,
-        user_manager,
-        user: UserModel,
+        user_manager: UserManager,
+        token_data: UserTokenData[UserModel, IDType],
     ):
-        await access_token_database.create({"token": "TOKEN", "user_id": user.id})
-        authenticated_user = await database_strategy.read_token("TOKEN", user_manager)
-        assert authenticated_user is not None
-        assert authenticated_user.id == user.id
+        await access_token_database.create(
+            {
+                "token": "TOKEN",
+                "user_id": token_data.user.id,
+                "scopes": token_data.scope,
+                **token_data.dict(exclude={"user_id", "user", "scopes"}),
+            }
+        )
+        access_token = await database_strategy.read_token("TOKEN", user_manager)
+        assert access_token is not None
+        assert access_token.dict() == token_data.dict()
 
 
 @pytest.mark.authentication
 @pytest.mark.asyncio
 async def test_write_token(
-    database_strategy: DatabaseStrategy[UserModel, IDType, AccessTokenModel],
+    database_strategy: DatabaseStrategy[AccessTokenModel],
     access_token_database: AccessTokenDatabaseMock,
-    user: UserModel,
+    token_data: UserTokenData[UserModel, IDType],
 ):
-    token = await database_strategy.write_token(user)
+    token = await database_strategy.write_token(token_data)
 
     access_token = await access_token_database.get_by_token(token)
-    assert access_token is not None
-    assert access_token.user_id == user.id
+    assert_valid_token_model(access_token, token_data)
 
 
 @pytest.mark.authentication
 @pytest.mark.asyncio
 async def test_destroy_token(
-    database_strategy: DatabaseStrategy[UserModel, IDType, AccessTokenModel],
+    database_strategy: DatabaseStrategy[AccessTokenModel],
     access_token_database: AccessTokenDatabaseMock,
     user: UserModel,
 ):

--- a/tests/test_authentication_strategy_jwt.py
+++ b/tests/test_authentication_strategy_jwt.py
@@ -1,13 +1,18 @@
+from datetime import datetime
+from typing import Any, Dict, Optional
+from uuid import UUID
+
+import jwt
 import pytest
+from pydantic import SecretStr
 
 from fastapi_users.authentication.strategy import (
     JWTStrategy,
     StrategyDestroyNotSupportedError,
 )
+from fastapi_users.authentication.token import UserTokenData
 from fastapi_users.jwt import SecretType, decode_jwt, generate_jwt
-from tests.conftest import IDType, UserModel
-
-LIFETIME = 3600
+from tests.conftest import IDType, UserManager, UserModel
 
 ECC_PRIVATE_KEY = """-----BEGIN PRIVATE KEY-----
 MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgewlS46hocOLtT9Px
@@ -59,32 +64,65 @@ owIDAQAB
 -----END PUBLIC KEY-----"""
 
 
-@pytest.fixture
-def jwt_strategy(request, secret: SecretType):
-    if request.param == "HS256":
-        return JWTStrategy(secret, LIFETIME)
-    elif request.param == "RS256":
-        return JWTStrategy(
-            RSA_PRIVATE_KEY, LIFETIME, algorithm="RS256", public_key=RSA_PUBLIC_KEY
-        )
-    elif request.param == "ES256":
-        return JWTStrategy(
-            ECC_PRIVATE_KEY, LIFETIME, algorithm="ES256", public_key=ECC_PUBLIC_KEY
-        )
-    raise ValueError(f"Unrecognized algorithm: {request.param}")
+@pytest.fixture(params=["SECRET"])
+def secret(request: pytest.FixtureRequest) -> SecretType:
+    return request.param  # type: ignore
+
+
+@pytest.fixture(params=["HS256"])
+def algorithm(request: pytest.FixtureRequest) -> str:
+    return request.param  # type: ignore
+
+
+@pytest.fixture(params=[None])
+def public_key(request: pytest.FixtureRequest) -> Optional[str]:
+    return request.param  # type: ignore
 
 
 @pytest.fixture
-def token(jwt_strategy: JWTStrategy[UserModel, IDType]):
-    def _token(user_id=None, lifetime=LIFETIME):
-        data = {"aud": "fastapi-users:auth"}
-        if user_id is not None:
-            data["user_id"] = str(user_id)
-        return generate_jwt(
-            data, jwt_strategy.encode_key, lifetime, algorithm=jwt_strategy.algorithm
-        )
+@pytest.mark.parametrize(
+    ("algorithm", "secret", "public_key"),
+    [
+        ("HS256", "SECRET", None),
+        ("HS256", SecretStr("SECRET"), None),
+        ("RS256", RSA_PRIVATE_KEY, RSA_PUBLIC_KEY),
+        ("ES256", ECC_PRIVATE_KEY, ECC_PUBLIC_KEY),
+    ],
+)
+def jwt_strategy(algorithm: str, secret: SecretType, public_key: Optional[str]):
+    if algorithm == "HS256":
+        return JWTStrategy(secret)  # use default values
+    else:
+        return JWTStrategy(secret, algorithm=algorithm, public_key=public_key)
 
-    return _token
+
+@pytest.fixture
+def user_id(request: pytest.FixtureRequest, user: UserModel) -> Optional[UUID]:
+    if hasattr(request, "param"):
+        return request.param  # type: ignore
+    else:
+        return user.id
+
+
+@pytest.fixture
+def jwt_token(
+    jwt_strategy: JWTStrategy,
+    token_data: UserTokenData[UserModel, IDType],
+    user_id: Optional[UUID],
+) -> str:
+    data: Dict[str, Any] = {"aud": "fastapi-users:auth"}
+
+    if user_id is not None:
+        data["sub"] = str(user_id)
+
+    if token_data.expires_at:
+        data["exp"] = int(token_data.expires_at.timestamp())
+
+    data["iat"] = int(token_data.created_at.timestamp())
+    data["auth_time"] = int(token_data.last_authenticated.timestamp())
+    data["scope"] = token_data.scope
+
+    return generate_jwt(data, jwt_strategy.encode_key, algorithm=jwt_strategy.algorithm)
 
 
 @pytest.mark.parametrize("jwt_strategy", ["HS256", "RS256", "ES256"], indirect=True)
@@ -92,68 +130,131 @@ def token(jwt_strategy: JWTStrategy[UserModel, IDType]):
 class TestReadToken:
     @pytest.mark.asyncio
     async def test_missing_token(
-        self, jwt_strategy: JWTStrategy[UserModel, IDType], user_manager
+        self,
+        jwt_strategy: JWTStrategy,
+        user_manager: UserManager,
     ):
         authenticated_user = await jwt_strategy.read_token(None, user_manager)
         assert authenticated_user is None
 
     @pytest.mark.asyncio
     async def test_invalid_token(
-        self, jwt_strategy: JWTStrategy[UserModel, IDType], user_manager
+        self,
+        jwt_strategy: JWTStrategy,
+        user_manager: UserManager,
     ):
         authenticated_user = await jwt_strategy.read_token("foo", user_manager)
         assert authenticated_user is None
 
     @pytest.mark.asyncio
-    async def test_valid_token_missing_user_payload(
-        self, jwt_strategy: JWTStrategy[UserModel, IDType], user_manager, token
+    @pytest.mark.parametrize(
+        "user_id",
+        [
+            None,
+            "foo",
+            "d35d213e-f3d8-4f08-954a-7e0d1bea286f",  # non-existent user
+        ],
+        indirect=True,
+    )
+    async def test_valid_token_invalid_user(
+        self,
+        jwt_strategy: JWTStrategy,
+        user_manager: UserManager,
+        jwt_token: str,
     ):
-        authenticated_user = await jwt_strategy.read_token(token(), user_manager)
+        authenticated_user = await jwt_strategy.read_token(jwt_token, user_manager)
         assert authenticated_user is None
-
-    @pytest.mark.asyncio
-    async def test_valid_token_invalid_uuid(
-        self, jwt_strategy: JWTStrategy[UserModel, IDType], user_manager, token
-    ):
-        authenticated_user = await jwt_strategy.read_token(token("foo"), user_manager)
-        assert authenticated_user is None
-
-    @pytest.mark.asyncio
-    async def test_valid_token_not_existing_user(
-        self, jwt_strategy: JWTStrategy[UserModel, IDType], user_manager, token
-    ):
-        authenticated_user = await jwt_strategy.read_token(
-            token("d35d213e-f3d8-4f08-954a-7e0d1bea286f"), user_manager
-        )
-        assert authenticated_user is None
-
-    @pytest.mark.asyncio
-    async def test_valid_token(
-        self, jwt_strategy: JWTStrategy[UserModel, IDType], user_manager, token, user
-    ):
-        authenticated_user = await jwt_strategy.read_token(token(user.id), user_manager)
-        assert authenticated_user is not None
-        assert authenticated_user.id == user.id
 
 
 @pytest.mark.parametrize("jwt_strategy", ["HS256", "RS256", "ES256"], indirect=True)
+@pytest.mark.parametrize("token_expired", [False], indirect=True)
 @pytest.mark.authentication
 @pytest.mark.asyncio
-async def test_write_token(jwt_strategy: JWTStrategy[UserModel, IDType], user):
-    token = await jwt_strategy.write_token(user)
-
+async def test_write_token(
+    jwt_strategy: JWTStrategy, token_data: UserTokenData[UserModel, IDType]
+):
+    token = await jwt_strategy.write_token(token_data)
     decoded = decode_jwt(
         token,
         jwt_strategy.decode_key,
         audience=jwt_strategy.token_audience,
         algorithms=[jwt_strategy.algorithm],
     )
-    assert decoded["user_id"] == str(user.id)
+    assert decoded["sub"] == str(token_data.user.id)
+    assert decoded["iat"] == int(token_data.created_at.timestamp())
+    assert decoded["scope"] == token_data.scope
+    assert decoded["auth_time"] == int(token_data.last_authenticated.timestamp())
+    if token_data.expires_at:
+        assert "exp" in decoded
+        assert decoded["exp"] == int(token_data.expires_at.timestamp())
+
+
+@pytest.mark.parametrize("jwt_strategy", ["HS256", "RS256", "ES256"], indirect=True)
+@pytest.mark.parametrize("token_expired", [True], indirect=True)
+@pytest.mark.authentication
+@pytest.mark.asyncio
+async def test_write_token_expired(
+    jwt_strategy: JWTStrategy, token_data: UserTokenData[UserModel, IDType]
+):
+    token = await jwt_strategy.write_token(token_data)
+
+    with pytest.raises(jwt.exceptions.ExpiredSignatureError):
+        decode_jwt(
+            token,
+            jwt_strategy.decode_key,
+            audience=jwt_strategy.token_audience,
+            algorithms=[jwt_strategy.algorithm],
+        )
+
+
+def assert_token_data_approximately_equal(
+    left: UserTokenData[UserModel, IDType], right: UserTokenData[UserModel, IDType]
+):
+    def assert_seconds_equal(left: datetime, right: datetime):
+        assert left.replace(microsecond=0) == right.replace(microsecond=0)
+
+    assert left.user == right.user
+    assert left.scopes == right.scopes
+    if left.expires_at and right.expires_at:
+        assert_seconds_equal(left.expires_at, right.expires_at)
+    else:
+        assert left.expires_at == right.expires_at
+    assert_seconds_equal(left.created_at, right.created_at)
+    assert_seconds_equal(left.last_authenticated, right.last_authenticated)
+
+
+@pytest.mark.parametrize("jwt_strategy", ["HS256", "RS256", "ES256"], indirect=True)
+@pytest.mark.parametrize("token_expired", [False], indirect=True)
+@pytest.mark.authentication
+@pytest.mark.asyncio
+async def test_read_token(
+    jwt_strategy: JWTStrategy,
+    token_data: UserTokenData[UserModel, IDType],
+    user_manager: UserManager,
+):
+    token = await jwt_strategy.write_token(token_data)
+    decoded = await jwt_strategy.read_token(token, user_manager)
+    assert decoded is not None
+    assert_token_data_approximately_equal(decoded, token_data)
+
+
+@pytest.mark.parametrize("jwt_strategy", ["HS256", "RS256", "ES256"], indirect=True)
+@pytest.mark.parametrize("token_expired", [True], indirect=True)
+@pytest.mark.authentication
+@pytest.mark.asyncio
+async def test_read_token_expired(
+    jwt_strategy: JWTStrategy,
+    token_data: UserTokenData[UserModel, IDType],
+    user_manager: UserManager,
+):
+    token = await jwt_strategy.write_token(token_data)
+    decoded = await jwt_strategy.read_token(token, user_manager)
+    assert decoded == None
 
 
 @pytest.mark.parametrize("jwt_strategy", ["HS256", "RS256", "ES256"], indirect=True)
 @pytest.mark.authentication
 @pytest.mark.asyncio
-async def test_destroy_token(jwt_strategy: JWTStrategy[UserModel, IDType], user):
+async def test_destroy_token(jwt_strategy: JWTStrategy, user: UserModel):
     with pytest.raises(StrategyDestroyNotSupportedError):
         await jwt_strategy.destroy_token("TOKEN", user)

--- a/tests/test_authentication_strategy_redis.py
+++ b/tests/test_authentication_strategy_redis.py
@@ -1,10 +1,12 @@
+import json
 from datetime import datetime
 from typing import Dict, Optional, Tuple
 
 import pytest
 
 from fastapi_users.authentication.strategy import RedisStrategy
-from tests.conftest import IDType, UserModel
+from fastapi_users.authentication.token import UserTokenData
+from tests.conftest import IDType, UserManager, UserModel
 
 
 class RedisMock:
@@ -42,29 +44,25 @@ def redis() -> RedisMock:
 
 @pytest.fixture
 def redis_strategy(redis):
-    return RedisStrategy(redis, 3600)
+    return RedisStrategy(redis)
 
 
 @pytest.mark.authentication
 class TestReadToken:
     @pytest.mark.asyncio
-    async def test_missing_token(
-        self, redis_strategy: RedisStrategy[UserModel, IDType], user_manager
-    ):
+    async def test_missing_token(self, redis_strategy: RedisStrategy, user_manager):
         authenticated_user = await redis_strategy.read_token(None, user_manager)
         assert authenticated_user is None
 
     @pytest.mark.asyncio
-    async def test_invalid_token(
-        self, redis_strategy: RedisStrategy[UserModel, IDType], user_manager
-    ):
+    async def test_invalid_token(self, redis_strategy: RedisStrategy, user_manager):
         authenticated_user = await redis_strategy.read_token("TOKEN", user_manager)
         assert authenticated_user is None
 
     @pytest.mark.asyncio
     async def test_valid_token_invalid_uuid(
         self,
-        redis_strategy: RedisStrategy[UserModel, IDType],
+        redis_strategy: RedisStrategy,
         redis: RedisMock,
         user_manager,
     ):
@@ -75,7 +73,7 @@ class TestReadToken:
     @pytest.mark.asyncio
     async def test_valid_token_not_existing_user(
         self,
-        redis_strategy: RedisStrategy[UserModel, IDType],
+        redis_strategy: RedisStrategy,
         redis: RedisMock,
         user_manager,
     ):
@@ -85,35 +83,69 @@ class TestReadToken:
         authenticated_user = await redis_strategy.read_token("TOKEN", user_manager)
         assert authenticated_user is None
 
-    @pytest.mark.asyncio
-    async def test_valid_token(
-        self,
-        redis_strategy: RedisStrategy[UserModel, IDType],
-        redis: RedisMock,
-        user_manager,
-        user,
-    ):
-        await redis.set(f"{redis_strategy.key_prefix}TOKEN", str(user.id))
-        authenticated_user = await redis_strategy.read_token("TOKEN", user_manager)
-        assert authenticated_user is not None
-        assert authenticated_user.id == user.id
 
-
+@pytest.mark.parametrize("token_expired", [False], indirect=True)
 @pytest.mark.authentication
 @pytest.mark.asyncio
 async def test_write_token(
-    redis_strategy: RedisStrategy[UserModel, IDType], redis: RedisMock, user
+    redis_strategy: RedisStrategy,
+    redis: RedisMock,
+    token_data: UserTokenData[UserModel, IDType],
 ):
-    token = await redis_strategy.write_token(user)
+    token = await redis_strategy.write_token(token_data)
+
+    token_value = await redis.get(f"{redis_strategy.key_prefix}{token}")
+    assert token_value is not None
+
+    decoded = json.loads(token_value)
+
+    assert decoded["user_id"] == str(token_data.user.id)
+    assert set(decoded["scopes"]) == token_data.scopes
+
+    assert datetime.fromisoformat(decoded["created_at"]) == token_data.created_at
+
+    assert (
+        datetime.fromisoformat(decoded["last_authenticated"])
+        == token_data.last_authenticated
+    )
+
+    if token_data.expires_at:
+        assert "expires_at" in decoded
+        assert datetime.fromisoformat(decoded["expires_at"]) == token_data.expires_at
+
+
+@pytest.mark.parametrize("token_expired", [True], indirect=True)
+@pytest.mark.authentication
+@pytest.mark.asyncio
+async def test_write_token_expired(
+    redis_strategy: RedisStrategy,
+    redis: RedisMock,
+    token_data: UserTokenData[UserModel, IDType],
+):
+    token = await redis_strategy.write_token(token_data)
 
     value = await redis.get(f"{redis_strategy.key_prefix}{token}")
-    assert value == str(user.id)
+    assert value is None
+
+
+@pytest.mark.parametrize("token_expired", [False], indirect=True)
+@pytest.mark.authentication
+@pytest.mark.asyncio
+async def test_read_token(
+    redis_strategy: RedisStrategy,
+    redis: RedisMock,
+    token_data: UserTokenData[UserModel, IDType],
+    user_manager: UserManager,
+):
+    token = await redis_strategy.write_token(token_data)
+    retrieved_token_data = await redis_strategy.read_token(token, user_manager)
+    assert retrieved_token_data == token_data
 
 
 @pytest.mark.authentication
 @pytest.mark.asyncio
 async def test_destroy_token(
-    redis_strategy: RedisStrategy[UserModel, IDType], redis: RedisMock, user
+    redis_strategy: RedisStrategy, redis: RedisMock, user: UserModel
 ):
     await redis.set(f"{redis_strategy.key_prefix}TOKEN", str(user.id))
 

--- a/tests/test_authentication_token.py
+++ b/tests/test_authentication_token.py
@@ -1,0 +1,52 @@
+import json
+from datetime import datetime
+
+import pytest
+
+from fastapi_users.authentication.token import TokenData, UserTokenData
+from tests.conftest import IDType, UserManager, UserModel
+
+
+@pytest.mark.authentication
+def test_token_to_json(token_data: UserTokenData[UserModel, IDType]):
+
+    token = token_data.json()
+
+    decoded = json.loads(token)
+
+    assert decoded["user_id"] == str(token_data.user.id)
+    assert set(decoded["scopes"]) == token_data.scopes
+
+    assert datetime.fromisoformat(decoded["created_at"]) == token_data.created_at
+
+    assert (
+        datetime.fromisoformat(decoded["last_authenticated"])
+        == token_data.last_authenticated
+    )
+
+    if token_data.expires_at:
+        assert "expires_at" in decoded
+        assert datetime.fromisoformat(decoded["expires_at"]) == token_data.expires_at
+
+
+@pytest.mark.authentication
+@pytest.mark.asyncio
+async def test_token_from_json(
+    token_data: UserTokenData[UserModel, IDType], user_manager: UserManager
+):
+
+    token_data_dict = {
+        "user_id": str(token_data.user.id),
+        "created_at": token_data.created_at.isoformat(),
+        "last_authenticated": token_data.last_authenticated.isoformat(),
+        "scopes": list(token_data.scopes),
+    }
+    if token_data.expires_at:
+        token_data_dict["expires_at"] = token_data.expires_at.isoformat()
+
+    token = json.dumps(token_data_dict)
+
+    parsed_token = TokenData.parse_raw(token)
+    parsed_user_token = await parsed_token.lookup_user(user_manager)
+
+    assert parsed_user_token == token_data

--- a/tests/test_authentication_transport_bearer.py
+++ b/tests/test_authentication_transport_bearer.py
@@ -4,6 +4,7 @@ from fastapi import Response, status
 from fastapi_users.authentication.transport import (
     BearerTransport,
     TransportLogoutNotSupportedError,
+    TransportTokenResponse,
 )
 from fastapi_users.authentication.transport.bearer import BearerResponse
 
@@ -17,11 +18,29 @@ def bearer_transport() -> BearerTransport:
 @pytest.mark.asyncio
 async def test_get_login_response(bearer_transport: BearerTransport):
     response = Response()
-    login_response = await bearer_transport.get_login_response("TOKEN", response)
+    token_response = TransportTokenResponse(access_token="TOKEN")
+    login_response = await bearer_transport.get_login_response(token_response, response)
 
     assert isinstance(login_response, BearerResponse)
 
     assert login_response.access_token == "TOKEN"
+    assert login_response.refresh_token == None
+    assert login_response.token_type == "bearer"
+
+
+@pytest.mark.authentication
+@pytest.mark.asyncio
+async def test_get_login_response_with_refresh(bearer_transport: BearerTransport):
+    response = Response()
+    token_response = TransportTokenResponse(
+        access_token="TOKEN", refresh_token="REFRESH_TOKEN"
+    )
+    login_response = await bearer_transport.get_login_response(token_response, response)
+
+    assert isinstance(login_response, BearerResponse)
+
+    assert login_response.access_token == "TOKEN"
+    assert login_response.refresh_token == "REFRESH_TOKEN"
     assert login_response.token_type == "bearer"
 
 

--- a/tests/test_authentication_transport_cookie.py
+++ b/tests/test_authentication_transport_cookie.py
@@ -3,7 +3,10 @@ import re
 import pytest
 from fastapi import Response, status
 
-from fastapi_users.authentication.transport import CookieTransport
+from fastapi_users.authentication.transport import (
+    CookieTransport,
+    TransportTokenResponse,
+)
 
 COOKIE_MAX_AGE = 3600
 COOKIE_NAME = "COOKIE_NAME"
@@ -39,7 +42,8 @@ async def test_get_login_response(cookie_transport: CookieTransport):
     httponly = cookie_transport.cookie_httponly
 
     response = Response()
-    login_response = await cookie_transport.get_login_response("TOKEN", response)
+    token_response = TransportTokenResponse(access_token="TOKEN")
+    login_response = await cookie_transport.get_login_response(token_response, response)
 
     assert login_response is None
 

--- a/tests/test_fastapi_users.py
+++ b/tests/test_fastapi_users.py
@@ -5,7 +5,14 @@ import pytest
 from fastapi import Depends, FastAPI, status
 
 from fastapi_users import FastAPIUsers
-from tests.conftest import IDType, User, UserCreate, UserModel, UserUpdate
+from tests.conftest import (
+    IDType,
+    User,
+    UserCreate,
+    UserModel,
+    UserUpdate,
+    mock_authorized_headers,
+)
 
 
 @pytest.fixture
@@ -167,7 +174,7 @@ class TestGetCurrentUser:
         self, test_app_client: httpx.AsyncClient, user: UserModel
     ):
         response = await test_app_client.get(
-            "/current-user", headers={"Authorization": f"Bearer {user.id}"}
+            "/current-user", headers=mock_authorized_headers(user)
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -190,7 +197,7 @@ class TestGetCurrentActiveUser:
     ):
         response = await test_app_client.get(
             "/current-active-user",
-            headers={"Authorization": f"Bearer {inactive_user.id}"},
+            headers=mock_authorized_headers(inactive_user),
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -198,7 +205,7 @@ class TestGetCurrentActiveUser:
         self, test_app_client: httpx.AsyncClient, user: UserModel
     ):
         response = await test_app_client.get(
-            "/current-active-user", headers={"Authorization": f"Bearer {user.id}"}
+            "/current-active-user", headers=mock_authorized_headers(user)
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -221,7 +228,7 @@ class TestGetCurrentVerifiedUser:
     ):
         response = await test_app_client.get(
             "/current-verified-user",
-            headers={"Authorization": f"Bearer {user.id}"},
+            headers=mock_authorized_headers(user),
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -230,7 +237,7 @@ class TestGetCurrentVerifiedUser:
     ):
         response = await test_app_client.get(
             "/current-verified-user",
-            headers={"Authorization": f"Bearer {verified_user.id}"},
+            headers=mock_authorized_headers(verified_user),
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -252,7 +259,7 @@ class TestGetCurrentSuperuser:
         self, test_app_client: httpx.AsyncClient, user: UserModel
     ):
         response = await test_app_client.get(
-            "/current-superuser", headers={"Authorization": f"Bearer {user.id}"}
+            "/current-superuser", headers=mock_authorized_headers(user)
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -260,7 +267,7 @@ class TestGetCurrentSuperuser:
         self, test_app_client: httpx.AsyncClient, superuser: UserModel
     ):
         response = await test_app_client.get(
-            "/current-superuser", headers={"Authorization": f"Bearer {superuser.id}"}
+            "/current-superuser", headers=mock_authorized_headers(superuser)
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -283,7 +290,7 @@ class TestGetCurrentVerifiedSuperuser:
     ):
         response = await test_app_client.get(
             "/current-verified-superuser",
-            headers={"Authorization": f"Bearer {user.id}"},
+            headers=mock_authorized_headers(user),
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -292,7 +299,7 @@ class TestGetCurrentVerifiedSuperuser:
     ):
         response = await test_app_client.get(
             "/current-verified-superuser",
-            headers={"Authorization": f"Bearer {verified_user.id}"},
+            headers=mock_authorized_headers(verified_user),
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -301,7 +308,7 @@ class TestGetCurrentVerifiedSuperuser:
     ):
         response = await test_app_client.get(
             "/current-verified-superuser",
-            headers={"Authorization": f"Bearer {superuser.id}"},
+            headers=mock_authorized_headers(superuser),
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -310,7 +317,7 @@ class TestGetCurrentVerifiedSuperuser:
     ):
         response = await test_app_client.get(
             "/current-verified-superuser",
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -334,7 +341,7 @@ class TestOptionalGetCurrentUser:
         self, test_app_client: httpx.AsyncClient, user: UserModel
     ):
         response = await test_app_client.get(
-            "/optional-current-user", headers={"Authorization": f"Bearer {user.id}"}
+            "/optional-current-user", headers=mock_authorized_headers(user)
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() is not None
@@ -360,7 +367,7 @@ class TestOptionalGetCurrentVerifiedUser:
     ):
         response = await test_app_client.get(
             "/optional-current-verified-user",
-            headers={"Authorization": f"Bearer {user.id}"},
+            headers=mock_authorized_headers(user),
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() is None
@@ -370,7 +377,7 @@ class TestOptionalGetCurrentVerifiedUser:
     ):
         response = await test_app_client.get(
             "/optional-current-verified-user",
-            headers={"Authorization": f"Bearer {verified_user.id}"},
+            headers=mock_authorized_headers(verified_user),
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() is not None
@@ -396,7 +403,7 @@ class TestOptionalGetCurrentActiveUser:
     ):
         response = await test_app_client.get(
             "/optional-current-active-user",
-            headers={"Authorization": f"Bearer {inactive_user.id}"},
+            headers=mock_authorized_headers(inactive_user),
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() is None
@@ -406,7 +413,7 @@ class TestOptionalGetCurrentActiveUser:
     ):
         response = await test_app_client.get(
             "/optional-current-active-user",
-            headers={"Authorization": f"Bearer {user.id}"},
+            headers=mock_authorized_headers(user),
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() is not None
@@ -432,7 +439,7 @@ class TestOptionalGetCurrentSuperuser:
     ):
         response = await test_app_client.get(
             "/optional-current-superuser",
-            headers={"Authorization": f"Bearer {user.id}"},
+            headers=mock_authorized_headers(user),
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() is None
@@ -442,7 +449,7 @@ class TestOptionalGetCurrentSuperuser:
     ):
         response = await test_app_client.get(
             "/optional-current-superuser",
-            headers={"Authorization": f"Bearer {superuser.id}"},
+            headers=mock_authorized_headers(superuser),
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() is not None
@@ -469,7 +476,7 @@ class TestOptionalGetCurrentVerifiedSuperuser:
     ):
         response = await test_app_client.get(
             "/optional-current-verified-superuser",
-            headers={"Authorization": f"Bearer {user.id}"},
+            headers=mock_authorized_headers(user),
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() is None
@@ -479,7 +486,7 @@ class TestOptionalGetCurrentVerifiedSuperuser:
     ):
         response = await test_app_client.get(
             "/optional-current-verified-superuser",
-            headers={"Authorization": f"Bearer {verified_user.id}"},
+            headers=mock_authorized_headers(verified_user),
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() is None
@@ -489,7 +496,7 @@ class TestOptionalGetCurrentVerifiedSuperuser:
     ):
         response = await test_app_client.get(
             "/optional-current-verified-superuser",
-            headers={"Authorization": f"Bearer {superuser.id}"},
+            headers=mock_authorized_headers(superuser),
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() is None
@@ -499,7 +506,7 @@ class TestOptionalGetCurrentVerifiedSuperuser:
     ):
         response = await test_app_client.get(
             "/optional-current-verified-superuser",
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.json() is not None

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -17,6 +17,7 @@ from fastapi_users.exceptions import (
 )
 from fastapi_users.jwt import decode_jwt, generate_jwt
 from fastapi_users.manager import IntegerIDMixin
+from fastapi_users.scopes import SystemScope
 from tests.conftest import (
     UserCreate,
     UserManagerMock,

--- a/tests/test_router_auth.py
+++ b/tests/test_router_auth.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncGenerator, Dict, Tuple, cast
+from typing import Any, AsyncGenerator, Callable, Dict, Optional, Tuple, cast
 
 import httpx
 import pytest
@@ -6,13 +6,23 @@ from fastapi import FastAPI, status
 
 from fastapi_users.authentication import Authenticator
 from fastapi_users.router import ErrorCode, get_auth_router
-from tests.conftest import UserModel, get_mock_authentication
+from fastapi_users.scopes import SystemScope
+from tests.conftest import (
+    MockBackend,
+    UserModel,
+    assert_valid_token_response,
+    mock_authorized_headers,
+    mock_token_data,
+)
 
 
 @pytest.fixture
-def app_factory(get_user_manager, mock_authentication):
+def app_factory(
+    mock_authentication_factory: Callable[[str], MockBackend], get_user_manager
+):
     def _app_factory(requires_verification: bool) -> FastAPI:
-        mock_authentication_bis = get_mock_authentication(name="mock-bis")
+        mock_authentication = mock_authentication_factory("mock")
+        mock_authentication_bis = mock_authentication_factory("mock-bis")
         authenticator = Authenticator(
             [mock_authentication, mock_authentication_bis], get_user_manager
         )
@@ -113,12 +123,17 @@ class TestLogin:
     @pytest.mark.parametrize(
         "email", ["king.arthur@camelot.bt", "King.Arthur@camelot.bt"]
     )
+    @pytest.mark.parametrize(
+        "access_token_lifetime_seconds", [None, 3600], indirect=True
+    )
+    @pytest.mark.freeze_time
     async def test_valid_credentials_unverified(
         self,
         path,
         email,
         test_app_client: Tuple[httpx.AsyncClient, bool],
         user: UserModel,
+        access_token_lifetime_seconds: Optional[int],
     ):
         client, requires_verification = test_app_client
         data = {"username": email, "password": "guinevere"}
@@ -129,27 +144,36 @@ class TestLogin:
             assert data["detail"] == ErrorCode.LOGIN_USER_NOT_VERIFIED
         else:
             assert response.status_code == status.HTTP_200_OK
-            assert response.json() == {
-                "access_token": str(user.id),
-                "token_type": "bearer",
-            }
+            expected_access_token = mock_token_data(
+                user_id=user.id,
+                scopes={SystemScope.USER},
+                lifetime_seconds=access_token_lifetime_seconds,
+            )
+            assert_valid_token_response(response.json(), expected_access_token)
 
     @pytest.mark.parametrize("email", ["lake.lady@camelot.bt", "Lake.Lady@camelot.bt"])
+    @pytest.mark.parametrize(
+        "access_token_lifetime_seconds", [None, 3600], indirect=True
+    )
+    @pytest.mark.freeze_time
     async def test_valid_credentials_verified(
         self,
         path,
         email,
         test_app_client: Tuple[httpx.AsyncClient, bool],
         verified_user: UserModel,
+        access_token_lifetime_seconds: Optional[int],
     ):
         client, _ = test_app_client
         data = {"username": email, "password": "excalibur"}
         response = await client.post(path, data=data)
         assert response.status_code == status.HTTP_200_OK
-        assert response.json() == {
-            "access_token": str(verified_user.id),
-            "token_type": "bearer",
-        }
+        expected_access_token = mock_token_data(
+            user_id=verified_user.id,
+            scopes={SystemScope.USER, SystemScope.VERIFIED},
+            lifetime_seconds=access_token_lifetime_seconds,
+        )
+        assert_valid_token_response(response.json(), expected_access_token)
 
     async def test_inactive_user(
         self,
@@ -185,9 +209,7 @@ class TestLogout:
         user: UserModel,
     ):
         client, requires_verification = test_app_client
-        response = await client.post(
-            path, headers={"Authorization": f"Bearer {user.id}"}
-        )
+        response = await client.post(path, headers=mock_authorized_headers(user))
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
         else:
@@ -202,7 +224,7 @@ class TestLogout:
     ):
         client, _ = test_app_client
         response = await client.post(
-            path, headers={"Authorization": f"Bearer {verified_user.id}"}
+            path, headers=mock_authorized_headers(verified_user)
         )
         assert response.status_code == status.HTTP_200_OK
 

--- a/tests/test_router_refresh.py
+++ b/tests/test_router_refresh.py
@@ -1,0 +1,173 @@
+from datetime import datetime
+from typing import AsyncGenerator, Callable, Optional, Tuple
+
+import httpx
+import pytest
+from fastapi import FastAPI, status
+
+from fastapi_users.authentication import Authenticator
+from fastapi_users.router import get_auth_router, get_refresh_router
+from fastapi_users.scopes import SystemScope
+from tests.conftest import (
+    MockBackend,
+    UserModel,
+    assert_valid_token_response,
+    mock_token_data,
+    mock_valid_access_token,
+    mock_valid_refresh_token,
+)
+
+
+@pytest.fixture
+def app_factory(
+    mock_authentication_factory: Callable[[str], MockBackend], get_user_manager
+):
+    def _app_factory(requires_verification: bool) -> FastAPI:
+        mock_authentication = mock_authentication_factory("mock")
+        mock_authentication_bis = mock_authentication_factory("mock-bis")
+        authenticator = Authenticator(
+            [mock_authentication, mock_authentication_bis], get_user_manager
+        )
+
+        mock_auth_router = get_auth_router(
+            mock_authentication,
+            get_user_manager,
+            authenticator,
+            requires_verification=requires_verification,
+        )
+        mock_bis_auth_router = get_auth_router(
+            mock_authentication_bis,
+            get_user_manager,
+            authenticator,
+            requires_verification=requires_verification,
+        )
+
+        mock_refresh_router = get_refresh_router(
+            mock_authentication,
+            get_user_manager,
+        )
+        mock_bis_refresh_router = get_refresh_router(
+            mock_authentication_bis,
+            get_user_manager,
+        )
+
+        app = FastAPI()
+        app.include_router(mock_auth_router, prefix="/mock")
+        app.include_router(mock_bis_auth_router, prefix="/mock-bis")
+        app.include_router(mock_refresh_router, prefix="/mock")
+        app.include_router(mock_bis_refresh_router, prefix="/mock-bis")
+
+        return app
+
+    return _app_factory
+
+
+@pytest.fixture(
+    params=[True, False], ids=["required_verification", "not_required_verification"]
+)
+@pytest.mark.asyncio
+async def test_app_client(
+    request, get_test_client, app_factory
+) -> AsyncGenerator[Tuple[httpx.AsyncClient, bool], None]:
+    requires_verification = request.param
+    app = app_factory(requires_verification)
+
+    async for client in get_test_client(app):
+        yield client, requires_verification
+
+
+@pytest.mark.router
+@pytest.mark.parametrize("refresh_token_enabled", [True], indirect=True)
+@pytest.mark.parametrize("path", ["/mock", "/mock-bis"])
+@pytest.mark.asyncio
+class TestRefresh:
+    async def test_malformed_token(
+        self,
+        path,
+        test_app_client: Tuple[httpx.AsyncClient, bool],
+    ):
+        client, _ = test_app_client
+        data = {"grant_type": "refresh_token", "refresh_token": "foo"}
+        response = await client.post(f"{path}/refresh", data=data)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    async def test_access_token_used_as_refresh_token(
+        self,
+        path,
+        test_app_client: Tuple[httpx.AsyncClient, bool],
+        verified_user: UserModel,
+    ):
+        client, _ = test_app_client
+
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": mock_valid_access_token(verified_user),
+        }
+        response = await client.post(f"{path}/refresh", data=data)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+
+    @pytest.mark.parametrize(
+        "access_token_lifetime_seconds", [None, 3600], indirect=True
+    )
+    @pytest.mark.parametrize(
+        "refresh_token_lifetime_seconds", [None, 86400], indirect=True
+    )
+    @pytest.mark.freeze_time("2022-09-01 09:00")
+    async def test_valid_refresh_token(
+        self,
+        path,
+        test_app_client: Tuple[httpx.AsyncClient, bool],
+        verified_user: UserModel,
+        freezer,
+        access_token_lifetime_seconds: Optional[int],
+        refresh_token_lifetime_seconds: Optional[int],
+    ):
+        print(f"test_valid_refresh_token: {access_token_lifetime_seconds}")
+        client, _ = test_app_client
+
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": mock_valid_refresh_token(verified_user),
+        }
+        freezer.move_to("2022-09-01 10:00")
+        response = await client.post(f"{path}/refresh", data=data)
+        assert response.status_code == status.HTTP_200_OK
+        expected_access_token = mock_token_data(
+            user_id=verified_user.id,
+            scopes={SystemScope.USER, SystemScope.VERIFIED},
+            lifetime_seconds=access_token_lifetime_seconds,
+            last_authenticated=datetime.fromisoformat("2022-09-01 09:00+00:00"),
+        )
+        expected_refresh_token = mock_token_data(
+            user_id=verified_user.id,
+            scopes={SystemScope.REFRESH},
+            lifetime_seconds=refresh_token_lifetime_seconds,
+            last_authenticated=datetime.fromisoformat("2022-09-01 09:00+00:00"),
+        )
+        assert_valid_token_response(
+            response.json(),
+            expected_access_token,
+            expected_refresh_token,
+        )
+
+
+@pytest.mark.router
+@pytest.mark.parametrize("refresh_token_enabled", [False], indirect=True)
+@pytest.mark.parametrize("path", ["/mock", "/mock-bis"])
+@pytest.mark.asyncio
+class TestMisconfiguredRefresh:
+    async def test_valid_refresh_token(
+        self,
+        path,
+        test_app_client: Tuple[httpx.AsyncClient, bool],
+        verified_user: UserModel,
+    ):
+        client, _ = test_app_client
+
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": mock_valid_refresh_token(verified_user),
+        }
+        response = await client.post(f"{path}/refresh", data=data)
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.json() == {"detail": "refresh_tokens_not_allowed"}

--- a/tests/test_router_users.py
+++ b/tests/test_router_users.py
@@ -6,7 +6,13 @@ from fastapi import FastAPI, status
 
 from fastapi_users.authentication import Authenticator
 from fastapi_users.router import ErrorCode, get_users_router
-from tests.conftest import User, UserModel, UserUpdate, get_mock_authentication
+from tests.conftest import (
+    User,
+    UserModel,
+    UserUpdate,
+    get_mock_authentication,
+    mock_authorized_headers,
+)
 
 
 @pytest.fixture
@@ -62,7 +68,7 @@ class TestMe:
     ):
         client, _ = test_app_client
         response = await client.get(
-            "/me", headers={"Authorization": f"Bearer {inactive_user.id}"}
+            "/me", headers=mock_authorized_headers(inactive_user)
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -72,9 +78,7 @@ class TestMe:
         user: UserModel,
     ):
         client, requires_verification = test_app_client
-        response = await client.get(
-            "/me", headers={"Authorization": f"Bearer {user.id}"}
-        )
+        response = await client.get("/me", headers=mock_authorized_headers(user))
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
         else:
@@ -90,7 +94,7 @@ class TestMe:
     ):
         client, _ = test_app_client
         response = await client.get(
-            "/me", headers={"Authorization": f"Bearer {verified_user.id}"}
+            "/me", headers=mock_authorized_headers(verified_user)
         )
         assert response.status_code == status.HTTP_200_OK
         data = cast(Dict[str, Any], response.json())
@@ -119,7 +123,7 @@ class TestUpdateMe:
     ):
         client, _ = test_app_client
         response = await client.patch(
-            "/me", headers={"Authorization": f"Bearer {inactive_user.id}"}
+            "/me", headers=mock_authorized_headers(inactive_user)
         )
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
@@ -133,7 +137,7 @@ class TestUpdateMe:
         response = await client.patch(
             "/me",
             json={"email": verified_user.email},
-            headers={"Authorization": f"Bearer {user.id}"},
+            headers=mock_authorized_headers(user),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -151,7 +155,7 @@ class TestUpdateMe:
         response = await client.patch(
             "/me",
             json={"password": "m"},
-            headers={"Authorization": f"Bearer {user.id}"},
+            headers=mock_authorized_headers(user),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -170,7 +174,7 @@ class TestUpdateMe:
     ):
         client, requires_verification = test_app_client
         response = await client.patch(
-            "/me", json={}, headers={"Authorization": f"Bearer {user.id}"}
+            "/me", json={}, headers=mock_authorized_headers(user)
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -188,7 +192,7 @@ class TestUpdateMe:
         client, requires_verification = test_app_client
         json = {"email": "king.arthur@tintagel.bt"}
         response = await client.patch(
-            "/me", json=json, headers={"Authorization": f"Bearer {user.id}"}
+            "/me", json=json, headers=mock_authorized_headers(user)
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -206,7 +210,7 @@ class TestUpdateMe:
         client, _ = test_app_client
         json = {"email": "king.arthur@tintagel.bt"}
         response = await client.patch(
-            "/me", json=json, headers={"Authorization": f"Bearer {verified_user.id}"}
+            "/me", json=json, headers=mock_authorized_headers(verified_user)
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -221,7 +225,7 @@ class TestUpdateMe:
         client, requires_verification = test_app_client
         json = {"is_superuser": True}
         response = await client.patch(
-            "/me", json=json, headers={"Authorization": f"Bearer {user.id}"}
+            "/me", json=json, headers=mock_authorized_headers(user)
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -239,7 +243,7 @@ class TestUpdateMe:
         client, requires_verification = test_app_client
         json = {"is_active": False}
         response = await client.patch(
-            "/me", json=json, headers={"Authorization": f"Bearer {user.id}"}
+            "/me", json=json, headers=mock_authorized_headers(user)
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -257,7 +261,7 @@ class TestUpdateMe:
         client, requires_verification = test_app_client
         json = {"is_verified": True}
         response = await client.patch(
-            "/me", json=json, headers={"Authorization": f"Bearer {user.id}"}
+            "/me", json=json, headers=mock_authorized_headers(user)
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -280,7 +284,7 @@ class TestUpdateMe:
 
         json = {"password": "merlin"}
         response = await client.patch(
-            "/me", json=json, headers={"Authorization": f"Bearer {user.id}"}
+            "/me", json=json, headers=mock_authorized_headers(user)
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -298,7 +302,7 @@ class TestUpdateMe:
     ):
         client, _ = test_app_client
         response = await client.patch(
-            "/me", json={}, headers={"Authorization": f"Bearer {verified_user.id}"}
+            "/me", json={}, headers=mock_authorized_headers(verified_user)
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -313,7 +317,7 @@ class TestUpdateMe:
         client, _ = test_app_client
         json = {"email": "king.arthur@tintagel.bt"}
         response = await client.patch(
-            "/me", json=json, headers={"Authorization": f"Bearer {verified_user.id}"}
+            "/me", json=json, headers=mock_authorized_headers(verified_user)
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -328,7 +332,7 @@ class TestUpdateMe:
         client, _ = test_app_client
         json = {"is_superuser": True}
         response = await client.patch(
-            "/me", json=json, headers={"Authorization": f"Bearer {verified_user.id}"}
+            "/me", json=json, headers=mock_authorized_headers(verified_user)
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -343,7 +347,7 @@ class TestUpdateMe:
         client, _ = test_app_client
         json = {"is_active": False}
         response = await client.patch(
-            "/me", json=json, headers={"Authorization": f"Bearer {verified_user.id}"}
+            "/me", json=json, headers=mock_authorized_headers(verified_user)
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -358,7 +362,7 @@ class TestUpdateMe:
         client, _ = test_app_client
         json = {"is_verified": False}
         response = await client.patch(
-            "/me", json=json, headers={"Authorization": f"Bearer {verified_user.id}"}
+            "/me", json=json, headers=mock_authorized_headers(verified_user)
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -378,7 +382,7 @@ class TestUpdateMe:
 
         json = {"password": "merlin"}
         response = await client.patch(
-            "/me", json=json, headers={"Authorization": f"Bearer {verified_user.id}"}
+            "/me", json=json, headers=mock_authorized_headers(verified_user)
         )
         assert response.status_code == status.HTTP_200_OK
         assert mock_user_db.update.called is True
@@ -403,7 +407,7 @@ class TestGetUser:
         client, requires_verification = test_app_client
         response = await client.get(
             "/d35d213e-f3d8-4f08-954a-7e0d1bea286f",
-            headers={"Authorization": f"Bearer {user.id}"},
+            headers=mock_authorized_headers(user),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -416,7 +420,7 @@ class TestGetUser:
         client, _ = test_app_client
         response = await client.get(
             "/d35d213e-f3d8-4f08-954a-7e0d1bea286f",
-            headers={"Authorization": f"Bearer {verified_user.id}"},
+            headers=mock_authorized_headers(verified_user),
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -428,7 +432,7 @@ class TestGetUser:
         client, requires_verification = test_app_client
         response = await client.get(
             "/d35d213e-f3d8-4f08-954a-7e0d1bea286f",
-            headers={"Authorization": f"Bearer {superuser.id}"},
+            headers=mock_authorized_headers(superuser),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -443,7 +447,7 @@ class TestGetUser:
         client, _ = test_app_client
         response = await client.get(
             "/d35d213e-f3d8-4f08-954a-7e0d1bea286f",
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -455,7 +459,7 @@ class TestGetUser:
     ):
         client, requires_verification = test_app_client
         response = await client.get(
-            f"/{user.id}", headers={"Authorization": f"Bearer {superuser.id}"}
+            f"/{user.id}", headers=mock_authorized_headers(superuser)
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -474,7 +478,7 @@ class TestGetUser:
     ):
         client, _ = test_app_client
         response = await client.get(
-            f"/{user.id}", headers={"Authorization": f"Bearer {verified_superuser.id}"}
+            f"/{user.id}", headers=mock_authorized_headers(verified_superuser)
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -502,7 +506,7 @@ class TestUpdateUser:
         client, requires_verification = test_app_client
         response = await client.patch(
             "/d35d213e-f3d8-4f08-954a-7e0d1bea286f",
-            headers={"Authorization": f"Bearer {user.id}"},
+            headers=mock_authorized_headers(user),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -515,7 +519,7 @@ class TestUpdateUser:
         client, _ = test_app_client
         response = await client.patch(
             "/d35d213e-f3d8-4f08-954a-7e0d1bea286f",
-            headers={"Authorization": f"Bearer {verified_user.id}"},
+            headers=mock_authorized_headers(verified_user),
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -528,7 +532,7 @@ class TestUpdateUser:
         response = await client.patch(
             "/d35d213e-f3d8-4f08-954a-7e0d1bea286f",
             json={},
-            headers={"Authorization": f"Bearer {superuser.id}"},
+            headers=mock_authorized_headers(superuser),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -544,7 +548,7 @@ class TestUpdateUser:
         response = await client.patch(
             "/d35d213e-f3d8-4f08-954a-7e0d1bea286f",
             json={},
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -556,7 +560,7 @@ class TestUpdateUser:
     ):
         client, requires_verification = test_app_client
         response = await client.patch(
-            f"/{user.id}", json={}, headers={"Authorization": f"Bearer {superuser.id}"}
+            f"/{user.id}", json={}, headers=mock_authorized_headers(superuser)
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -576,7 +580,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json={},
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -594,7 +598,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json=json,
-            headers={"Authorization": f"Bearer {superuser.id}"},
+            headers=mock_authorized_headers(superuser),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -615,7 +619,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json={"email": verified_user.email},
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         data = cast(Dict[str, Any], response.json())
@@ -631,7 +635,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json={"password": "m"},
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         data = cast(Dict[str, Any], response.json())
@@ -651,7 +655,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json=json,
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -669,7 +673,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json=json,
-            headers={"Authorization": f"Bearer {superuser.id}"},
+            headers=mock_authorized_headers(superuser),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -690,7 +694,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json=json,
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -708,7 +712,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json=json,
-            headers={"Authorization": f"Bearer {superuser.id}"},
+            headers=mock_authorized_headers(superuser),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -729,7 +733,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json=json,
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -747,7 +751,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json=json,
-            headers={"Authorization": f"Bearer {superuser.id}"},
+            headers=mock_authorized_headers(superuser),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -768,7 +772,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json=json,
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_200_OK
 
@@ -791,7 +795,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json=json,
-            headers={"Authorization": f"Bearer {superuser.id}"},
+            headers=mock_authorized_headers(superuser),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -818,7 +822,7 @@ class TestUpdateUser:
         response = await client.patch(
             f"/{user.id}",
             json=json,
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_200_OK
         assert mock_user_db.update.called is True
@@ -843,7 +847,7 @@ class TestDeleteUser:
         client, requires_verification = test_app_client
         response = await client.delete(
             "/d35d213e-f3d8-4f08-954a-7e0d1bea286f",
-            headers={"Authorization": f"Bearer {user.id}"},
+            headers=mock_authorized_headers(user),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -856,7 +860,7 @@ class TestDeleteUser:
         client, _ = test_app_client
         response = await client.delete(
             "/d35d213e-f3d8-4f08-954a-7e0d1bea286f",
-            headers={"Authorization": f"Bearer {verified_user.id}"},
+            headers=mock_authorized_headers(verified_user),
         )
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
@@ -868,7 +872,7 @@ class TestDeleteUser:
         client, requires_verification = test_app_client
         response = await client.delete(
             "/d35d213e-f3d8-4f08-954a-7e0d1bea286f",
-            headers={"Authorization": f"Bearer {superuser.id}"},
+            headers=mock_authorized_headers(superuser),
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -883,7 +887,7 @@ class TestDeleteUser:
         client, _ = test_app_client
         response = await client.delete(
             "/d35d213e-f3d8-4f08-954a-7e0d1bea286f",
-            headers={"Authorization": f"Bearer {verified_superuser.id}"},
+            headers=mock_authorized_headers(verified_superuser),
         )
         assert response.status_code == status.HTTP_404_NOT_FOUND
 
@@ -899,7 +903,7 @@ class TestDeleteUser:
         mocker.spy(mock_user_db, "delete")
 
         response = await client.delete(
-            f"/{user.id}", headers={"Authorization": f"Bearer {superuser.id}"}
+            f"/{user.id}", headers=mock_authorized_headers(superuser)
         )
         if requires_verification:
             assert response.status_code == status.HTTP_403_FORBIDDEN
@@ -923,7 +927,7 @@ class TestDeleteUser:
         mocker.spy(mock_user_db, "delete")
 
         response = await client.delete(
-            f"/{user.id}", headers={"Authorization": f"Bearer {verified_superuser.id}"}
+            f"/{user.id}", headers=mock_authorized_headers(verified_superuser)
         )
         assert response.status_code == status.HTTP_204_NO_CONTENT
         assert response.content == b""


### PR DESCRIPTION
This is a draft for feedback, and follows on from this discussion earlier in the year: https://github.com/fastapi-users/fastapi-users/discussions/350

I've made a first attempt here at implementing refresh tokens and the "freshness pattern" from `fastapi-jwt-auth`. It doesn't yet have any updates to docs, etc, as I'd like to get your initial input first.

## Breaking changes

Any implementation of these features involves breaking changes to parts of the API. This is, unfortunately, inevitable because any solution will need to address these challenges:

### Token metadata

It's no longer sufficient to determine whether a token simply exists for a given user and strategy, because we now also need to:

- Determine a token's "fresh" status
- Distinguish between an access token and a refresh token

For `JWTStrategy` this is straightforward (adding additional claims to the token), but for other strategies this requires non-backward-compatible changes. In this solution, that includes storing JSON in the Redis value for `RedisStrategy` and adding additional fields for `DatabaseStrategy`.

We also need to consider how to store and retrieve this metadata with the `Strategy`. For this I propose a Pydantic model, `UserTokenData`, which wraps the user object (conforming to `UserProtocol`) and its metadata. In this first draft I've created four metadata fields:

| Field | Description |
| --- | --- | 
| `created_at: datetime` | the UTC datetime when the token was issued |
| `expires_at: Optional[datetime]` | the UTC datetime when the token expires - this is no longer set by the `Strategy` but passed in by the `AuthenticationBackend` (see below) |
| `last_authenticated: datetime` | the UTC datetime when the user was last explicitly authenticated (not with a refresh token) - a token is considered "fresh" when `created_at == last_authenticated` |
| `scopes: Set[str]` | distinguishes between an access and refresh token, and can be extended for other purposes later |

### Token response model

It's now no longer sufficient for a `Transport` instance to receive a string as a token, as it now needs to process an access tokan and (optionally) a refresh token. In this draft I've created a model

```
class TransportTokenResponse(BaseModel):
    access_token: str
    refresh_token: Optional[str] = None
```

which replaces the previous `str` type expected by `Transport.get_login_response`.

### Moving token lifetime to `AuthenticationBackend`

As access tokens and refresh tokens have different lifetimes - and this could be extended to other token types in future - I've proposed removing the token lifetime configuration from `Strategy` and instead setting it in `AuthenticationBackend`, as well as whether refresh tokens should be generated and accepted:

        access_token_lifetime_seconds: Optional[int] = 3600,
        refresh_token_enabled: bool = False,
        refresh_token_lifetime_seconds: Optional[int] = 86400,

## New features

### New refresh router

I've added an OAuth2-compatible token refresh router, `get_refresh_router` in `refresh.py` for processing refresh tokens.

### New "fresh" keyword arg in `Authenticator` methods

- The public methods in `Authenticator` now have a `fresh: bool` keyword arg, which, when true, will throw `403 Forbidden` if the token is not fresh.
- I've also added an additional method, `current_token`, for users who need to inspect the token metadata.

### Scopes

I've borrowed the concept of OAuth2 scopes to distinguish between access tokens and refresh tokens, and I've also defined some additional scopes to distinguish between classes of users.

| Enum | String | Description |
| --- | --- | --- |
| `SystemScope.USER` | `"fastapi-users:user"` | An access token belonging to an active user |
| `SystemScope.SUPERUSER` | `"fastapi-users:superuser"` | An access token belonging to an active superuser |
| `SystemScope.VERIFIED` | `"fastapi-users:verified"` | An access token belonging to an active and verified user |
| `SystemScope.REFRESH` | `"fastapi-users:refresh"` | A refresh token |

This could be developed further - for example, both system- and user-defined routes could have "required scopes" that restrict what routes a particular token is permitted to access. By adding user-defined scopes, this could be used as a basis for a general-purpose user permissions system.

## Feedback welcome

Please let me know whether this is heading in the right direction and what other changes / different approaches you might have in mind!