### PR TITLE
on_after_login hook

### DIFF
--- a/docs/configuration/user-manager.md
+++ b/docs/configuration/user-manager.md
@@ -164,6 +164,33 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         print(f"User {user.id} has been updated with {update_dict}.")
 ```
 
+#### `on_after_login`
+
+Perform logic after a successful user login.
+
+It may be useful for custom logic or processes triggered by new logins, for example a daily login reward or for analytics.
+
+**Arguments**
+
+* `user` (`User`): the updated user.
+* `request` (`Optional[Request]`): optional FastAPI request object that triggered the operation. Defaults to None.
+
+**Example**
+
+```py
+from fastapi_users import BaseUserManager, UUIDIDMixin
+
+
+class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
+    # ...
+    async def on_after_login(
+        self,
+        user: User,
+        request: Optional[Request] = None,
+    ):
+        print(f"User {user.id} logged in.")
+```
+
 #### `on_after_request_verify`
 
 Perform logic after successful verification request.

--- a/fastapi_users/manager.py
+++ b/fastapi_users/manager.py
@@ -571,6 +571,20 @@ class BaseUserManager(Generic[models.UP, models.ID]):
         """
         return  # pragma: no cover
 
+    async def on_after_login(
+        self, user: models.UP, request: Optional[Request] = None
+    ) -> None:
+        """
+        Perform logic after user login.
+
+        *You should overload this method to add your own logic.*
+
+        :param user: The user that is logging in
+        :param request: Optional FastAPI request that
+        triggered the operation, defaults to None.
+        """
+        return  # pragma: no cover
+
     async def on_before_delete(
         self, user: models.UP, request: Optional[Request] = None
     ) -> None:

--- a/fastapi_users/router/auth.py
+++ b/fastapi_users/router/auth.py
@@ -66,7 +66,9 @@ def get_auth_router(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=ErrorCode.LOGIN_USER_NOT_VERIFIED,
             )
-        return await backend.login(strategy, user, response)
+        login_return = await backend.login(strategy, user, response)
+        await user_manager.on_after_login(user) #TODO: request
+        return login_return
 
     logout_responses: OpenAPIResponseType = {
         **{

--- a/fastapi_users/router/auth.py
+++ b/fastapi_users/router/auth.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from fastapi.security import OAuth2PasswordRequestForm
 
 from fastapi_users import models
@@ -49,6 +49,7 @@ def get_auth_router(
         responses=login_responses,
     )
     async def login(
+        request: Request,
         response: Response,
         credentials: OAuth2PasswordRequestForm = Depends(),
         user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
@@ -67,7 +68,7 @@ def get_auth_router(
                 detail=ErrorCode.LOGIN_USER_NOT_VERIFIED,
             )
         login_return = await backend.login(strategy, user, response)
-        await user_manager.on_after_login(user) #TODO: request
+        await user_manager.on_after_login(user, request)
         return login_return
 
     logout_responses: OpenAPIResponseType = {

--- a/fastapi_users/router/oauth.py
+++ b/fastapi_users/router/oauth.py
@@ -140,7 +140,9 @@ def get_oauth_router(
             )
 
         # Authenticate
-        return await backend.login(strategy, user, response)
+        login_return = await backend.login(strategy, user, response)
+        await user_manager.on_after_login(user, request)
+        return login_return
 
     return router
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -122,6 +122,7 @@ class UserManagerMock(BaseTestUserManager[models.UP]):
     on_after_update: MagicMock
     on_before_delete: MagicMock
     on_after_delete: MagicMock
+    on_after_login: MagicMock
     _update: MagicMock
 
 
@@ -479,6 +480,7 @@ def make_user_manager(mocker: MockerFixture):
         mocker.spy(user_manager, "on_after_update")
         mocker.spy(user_manager, "on_before_delete")
         mocker.spy(user_manager, "on_after_delete")
+        mocker.spy(user_manager, "on_after_login")
         mocker.spy(user_manager, "_update")
         return user_manager
 

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -595,6 +595,7 @@ class TestAuthenticate:
         form = create_oauth2_password_request_form("lancelot@camelot.bt", "guinevere")
         user = await user_manager.authenticate(form)
         assert user is None
+        assert user_manager.on_after_login.called is False
 
     async def test_wrong_password(
         self,
@@ -606,6 +607,7 @@ class TestAuthenticate:
         form = create_oauth2_password_request_form("king.arthur@camelot.bt", "percival")
         user = await user_manager.authenticate(form)
         assert user is None
+        assert user_manager.on_after_login.called is False
 
     async def test_valid_credentials(
         self,
@@ -620,6 +622,7 @@ class TestAuthenticate:
         user = await user_manager.authenticate(form)
         assert user is not None
         assert user.email == "king.arthur@camelot.bt"
+        assert user_manager.on_after_login.called is True
 
     async def test_upgrade_password_hash(
         self,

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -595,7 +595,6 @@ class TestAuthenticate:
         form = create_oauth2_password_request_form("lancelot@camelot.bt", "guinevere")
         user = await user_manager.authenticate(form)
         assert user is None
-        assert user_manager.on_after_login.called is False
 
     async def test_wrong_password(
         self,
@@ -607,7 +606,6 @@ class TestAuthenticate:
         form = create_oauth2_password_request_form("king.arthur@camelot.bt", "percival")
         user = await user_manager.authenticate(form)
         assert user is None
-        assert user_manager.on_after_login.called is False
 
     async def test_valid_credentials(
         self,
@@ -622,7 +620,6 @@ class TestAuthenticate:
         user = await user_manager.authenticate(form)
         assert user is not None
         assert user.email == "king.arthur@camelot.bt"
-        assert user_manager.on_after_login.called is True
 
     async def test_upgrade_password_hash(
         self,

--- a/tests/test_router_auth.py
+++ b/tests/test_router_auth.py
@@ -67,7 +67,7 @@ class TestLogin:
         response = await client.post(path, data={})
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         assert user_manager.on_after_login.called is False
-        
+
     async def test_missing_username(
         self,
         path,
@@ -179,6 +179,7 @@ class TestLogin:
         data = cast(Dict[str, Any], response.json())
         assert data["detail"] == ErrorCode.LOGIN_BAD_CREDENTIALS
         assert user_manager.on_after_login.called is False
+
 
 @pytest.mark.router
 @pytest.mark.parametrize("path", ["/mock/logout", "/mock-bis/logout"])

--- a/tests/test_router_oauth.py
+++ b/tests/test_router_oauth.py
@@ -188,6 +188,8 @@ class TestCallback:
         data = cast(Dict[str, Any], response.json())
         assert data["detail"] == ErrorCode.OAUTH_USER_ALREADY_EXISTS
 
+        assert user_manager_oauth.on_after_login.called is False
+
     async def test_active_user(
         self,
         async_method_mocker: AsyncMethodMocker,
@@ -216,6 +218,8 @@ class TestCallback:
         data = cast(Dict[str, Any], response.json())
         assert data["access_token"] == str(user_oauth.id)
 
+        assert user_manager_oauth.on_after_login.called is True
+
     async def test_inactive_user(
         self,
         async_method_mocker: AsyncMethodMocker,
@@ -242,6 +246,7 @@ class TestCallback:
         )
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert user_manager_oauth.on_after_login.called is False
 
     async def test_redirect_url_router(
         self,
@@ -276,6 +281,7 @@ class TestCallback:
 
         data = cast(Dict[str, Any], response.json())
         assert data["access_token"] == str(user_oauth.id)
+        assert user_manager_oauth.on_after_login.called is True
 
 
 @pytest.mark.router


### PR DESCRIPTION
Hi - I needed `on_after_login` so added this. Questions: 

- Is the spot logical for an on-after method? Is after the internal login call.

- Would `on_before_login` be needed? Maybe not, as auth is the way to do pre-login things.

Added fastapi request as a param just in case, as other callbacks had it too. Didn't implement sending it yet though, but can finish these things if the idea makes sense.

Docs addition is missing, unit test also.