### PR TITLE
Add login_return to on_after_login method

### DIFF
--- a/docs/configuration/user-manager.md
+++ b/docs/configuration/user-manager.md
@@ -187,6 +187,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         self,
         user: User,
         request: Optional[Request] = None,
+        login_return: Optional[Any] = None,
     ):
         print(f"User {user.id} logged in.")
 ```

--- a/fastapi_users/manager.py
+++ b/fastapi_users/manager.py
@@ -586,7 +586,10 @@ class BaseUserManager(Generic[models.UP, models.ID]):
         return  # pragma: no cover
 
     async def on_after_login(
-        self, user: models.UP, request: Optional[Request] = None
+        self,
+        user: models.UP,
+        request: Optional[Request] = None,
+        login_return: Optional[Any] = None,
     ) -> None:
         """
         Perform logic after user login.
@@ -594,7 +597,8 @@ class BaseUserManager(Generic[models.UP, models.ID]):
         *You should overload this method to add your own logic.*
 
         :param user: The user that is logging in
-        :param request: Optional FastAPI request that
+        :param request: Optional FastAPI request
+        :param login_return: Optional return of the login
         triggered the operation, defaults to None.
         """
         return  # pragma: no cover

--- a/fastapi_users/router/auth.py
+++ b/fastapi_users/router/auth.py
@@ -68,7 +68,7 @@ def get_auth_router(
                 detail=ErrorCode.LOGIN_USER_NOT_VERIFIED,
             )
         login_return = await backend.login(strategy, user, response)
-        await user_manager.on_after_login(user, request)
+        await user_manager.on_after_login(user, request, login_return)
         return login_return
 
     logout_responses: OpenAPIResponseType = {

--- a/fastapi_users/router/oauth.py
+++ b/fastapi_users/router/oauth.py
@@ -149,7 +149,7 @@ def get_oauth_router(
 
         # Authenticate
         login_return = await backend.login(strategy, user, response)
-        await user_manager.on_after_login(user, request)
+        await user_manager.on_after_login(user, request, login_return)
         return login_return
 
     return router

--- a/tests/test_router_auth.py
+++ b/tests/test_router_auth.py
@@ -165,6 +165,9 @@ class TestLogin:
             "token_type": "bearer",
         }
         assert user_manager.on_after_login.called is True
+        args, kwargs = user_manager.on_after_login.call_args
+        assert len(args) == 3
+        assert all(x is not None for x in args)
 
     async def test_inactive_user(
         self,


### PR DESCRIPTION
Hi there!

## Why this change ? 

I've been doing some search about logout with JWT, I noticed that you suggested that we could store the JWT Token in database and check if it exists or not. That's what I wanted to do, but I noticed that they were not an easy way (unless I'm mistaken) to get the token generated by the user.

That's why I opened this pull request, this is an optional argument so backward compatibility is preserved for people who already redefined this method.

Thanks!
