### PR TITLE
Update verify.py

### DIFF
--- a/fastapi_users/router/verify.py
+++ b/fastapi_users/router/verify.py
@@ -69,7 +69,8 @@ def get_verify_router(
         user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
     ):
         try:
-            return await user_manager.verify(token, request)
+            user = await user_manager.verify(token, request)
+            return user_schema.parse_obj(user)
         except (exceptions.InvalidVerifyToken, exceptions.UserNotExists):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,

--- a/fastapi_users/router/verify.py
+++ b/fastapi_users/router/verify.py
@@ -70,7 +70,7 @@ def get_verify_router(
     ):
         try:
             user = await user_manager.verify(token, request)
-            return user_schema.parse_obj(user)
+            return user_schema.from_orm(user)
         except (exceptions.InvalidVerifyToken, exceptions.UserNotExists):
             raise HTTPException(
                 status_code=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
When using a schema setup as proposed in the documentation like: ReadUser, CreateUser, UpdateUser and BaseUser in the combination with MongoDB / Beanie, the verify() method will not "enforce" the `user_schema` but instead will return the `BaseUser` which will cause serialisation errors as such:

```
pydantic.error_wrappers.ValidationError: 1 validation error for ReadUser
response -> id
```
because the mapping between MongoDBs internal `_id` and the Pydantic `id` does not work.