### PR TITLE
Add AsyncIterator to the DependencyCallable type

### DIFF
--- a/fastapi_users/types.py
+++ b/fastapi_users/types.py
@@ -1,4 +1,4 @@
-from typing import AsyncGenerator, Callable, Coroutine, Generator, TypeVar, Union
+from typing import AsyncGenerator, AsyncIterator, Callable, Coroutine, Generator, TypeVar, Union
 
 RETURN_TYPE = TypeVar("RETURN_TYPE")
 
@@ -9,5 +9,6 @@ DependencyCallable = Callable[
         Coroutine[None, None, RETURN_TYPE],
         AsyncGenerator[RETURN_TYPE, None],
         Generator[RETURN_TYPE, None, None],
+        AsyncIterator[RETURN_TYPE],
     ],
 ]

--- a/fastapi_users/types.py
+++ b/fastapi_users/types.py
@@ -1,4 +1,12 @@
-from typing import AsyncGenerator, AsyncIterator, Callable, Coroutine, Generator, TypeVar, Union
+from typing import (
+    AsyncGenerator,
+    AsyncIterator,
+    Callable,
+    Coroutine,
+    Generator,
+    TypeVar,
+    Union,
+)
 
 RETURN_TYPE = TypeVar("RETURN_TYPE")
 


### PR DESCRIPTION
Changes introduced by this PR:
- Added `AsyncIterator` to the `DependencyCallable` type.

Current Behavior:
- The `DependencyCallable` type includes `Coroutine`, `AsyncGenerator`, and `Generator` as valid callable types.
- Causes errors when utilizing a dependency that returns an `AsyncIterator` instead of an `AsyncGenerator`.

New Behavior:
- The `DependencyCallable` type includes `Coroutine`, `AsyncGenerator`, `Generator`, and `AsyncIterator` as valid callable types.
- This addition allows for the usage of `AsyncIterator` as a return type in the `DependencyCallable` type.

Please refer to #1229 for additional context.