### PR TITLE
fix: Add Pydantic v2 compatibility

### DIFF
--- a/fastapi_users/schemas.py
+++ b/fastapi_users/schemas.py
@@ -7,20 +7,34 @@ from fastapi_users import models
 
 class CreateUpdateDictModel(BaseModel):
     def create_update_dict(self):
-        return self.model_dump(
-            exclude_unset=True,
-            exclude={
-                "id",
-                "is_superuser",
-                "is_active",
-                "is_verified",
-                "oauth_accounts",
-            },
-        )
+        if getattr(self, "dict"):
+            return self.dict(
+                exclude_unset=True,
+                exclude={
+                    "id",
+                    "is_superuser",
+                    "is_active",
+                    "is_verified",
+                    "oauth_accounts",
+                },
+            )
+        else:
+            return self.model_dump(
+                exclude_unset=True,
+                exclude={
+                    "id",
+                    "is_superuser",
+                    "is_active",
+                    "is_verified",
+                    "oauth_accounts",
+                },
+            )
 
     def create_update_dict_superuser(self):
-        return self.model_dump(exclude_unset=True, exclude={"id"})
-
+        if getattr(self, "dict"):
+            return self.dict(exclude_unset=True, exclude={"id"})
+        else:
+            return self.model_dump(exclude_unset=True, exclude={"id"})
 
 class BaseUser(Generic[models.ID], CreateUpdateDictModel):
     """Base User model."""
@@ -30,6 +44,9 @@ class BaseUser(Generic[models.ID], CreateUpdateDictModel):
     is_active: bool = True
     is_superuser: bool = False
     is_verified: bool = False
+
+    class Config:
+        orm_mode = True
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -65,6 +82,9 @@ class BaseOAuthAccount(Generic[models.ID], BaseModel):
     refresh_token: Optional[str] = None
     account_id: str
     account_email: str
+
+    class Config:
+        orm_mode = True
 
     model_config = ConfigDict(from_attributes = True)
 

--- a/fastapi_users/schemas.py
+++ b/fastapi_users/schemas.py
@@ -1,6 +1,6 @@
 from typing import Generic, List, Optional, TypeVar
 
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, EmailStr
 
 from fastapi_users import models
 
@@ -36,6 +36,7 @@ class CreateUpdateDictModel(BaseModel):
         else:
             return self.model_dump(exclude_unset=True, exclude={"id"})
 
+
 class BaseUser(Generic[models.ID], CreateUpdateDictModel):
     """Base User model."""
 
@@ -47,8 +48,7 @@ class BaseUser(Generic[models.ID], CreateUpdateDictModel):
 
     class Config:
         orm_mode = True
-
-    model_config = ConfigDict(from_attributes=True)
+        from_attributes = True
 
 
 class BaseUserCreate(CreateUpdateDictModel):
@@ -85,8 +85,7 @@ class BaseOAuthAccount(Generic[models.ID], BaseModel):
 
     class Config:
         orm_mode = True
-
-    model_config = ConfigDict(from_attributes = True)
+        from_attributes = True
 
 
 class BaseOAuthAccountMixin(BaseModel):

--- a/fastapi_users/schemas.py
+++ b/fastapi_users/schemas.py
@@ -1,13 +1,13 @@
 from typing import Generic, List, Optional, TypeVar
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr
 
 from fastapi_users import models
 
 
 class CreateUpdateDictModel(BaseModel):
     def create_update_dict(self):
-        return self.dict(
+        return self.model_dump(
             exclude_unset=True,
             exclude={
                 "id",
@@ -19,7 +19,7 @@ class CreateUpdateDictModel(BaseModel):
         )
 
     def create_update_dict_superuser(self):
-        return self.dict(exclude_unset=True, exclude={"id"})
+        return self.model_dump(exclude_unset=True, exclude={"id"})
 
 
 class BaseUser(Generic[models.ID], CreateUpdateDictModel):
@@ -31,8 +31,7 @@ class BaseUser(Generic[models.ID], CreateUpdateDictModel):
     is_superuser: bool = False
     is_verified: bool = False
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes=True)
 
 
 class BaseUserCreate(CreateUpdateDictModel):
@@ -67,8 +66,7 @@ class BaseOAuthAccount(Generic[models.ID], BaseModel):
     account_id: str
     account_email: str
 
-    class Config:
-        orm_mode = True
+    model_config = ConfigDict(from_attributes = True)
 
 
 class BaseOAuthAccountMixin(BaseModel):

--- a/fastapi_users/schemas.py
+++ b/fastapi_users/schemas.py
@@ -7,7 +7,7 @@ from fastapi_users import models
 
 class CreateUpdateDictModel(BaseModel):
     def create_update_dict(self):
-        if getattr(self, "dict"):
+        if hasattr(self, "dict"):
             return self.dict(
                 exclude_unset=True,
                 exclude={
@@ -31,7 +31,7 @@ class CreateUpdateDictModel(BaseModel):
             )
 
     def create_update_dict_superuser(self):
-        if getattr(self, "dict"):
+        if hasattr(self, "dict"):
             return self.dict(exclude_unset=True, exclude={"id"})
         else:
             return self.model_dump(exclude_unset=True, exclude={"id"})

--- a/tests/test_pydantic_v2.py
+++ b/tests/test_pydantic_v2.py
@@ -1,0 +1,20 @@
+import pytest
+
+from fastapi_users.schemas import BaseUser
+from pydantic import BaseModel
+
+
+@pytest.mark.asyncio
+async def test_pydantic_v2(monkeypatch: pytest.MonkeyPatch):
+    if hasattr(BaseModel, "dict"):
+        # Swap the dict attribute for the new model_dump method
+        BaseModel.model_dump = BaseModel.dict
+
+        # Remove the old method
+        monkeypatch.delattr(BaseModel, "dict")
+
+        user = BaseUser(email="king.arthur@tintagel.bt")
+
+        # Test CreateUpdateDictModel as if we were running Pydantic v2
+        user.create_update_dict()
+        user.create_update_dict_superuser()


### PR DESCRIPTION
Updates the schema to be compatible with Pydantic v2 while remaining backwards-compatible with v1. This would resolve issue #1246.

I've used `hasattr` to see if fastapi-users is running with Pydantic v1 or v2, based on the presence of `BaseModel.dict`. If it's present, we're running on Pydantic v1. If not, we're using Pydantic v2 and use the `BaseModel.model_dump` method instead.

TODO:

Functional testing with Pydantic v2 exposes this error: `pydantic.errors.PydanticUserError: "Config" and "model_config" cannot be used together`. I'll have to think of another way to selectively toggle between Config and model_config.