### PR TITLE
docs(example): sqlmodel

### DIFF
--- a/docs/configuration/full-example.md
+++ b/docs/configuration/full-example.md
@@ -86,6 +86,70 @@ Here is a full working example with JWT authentication to help get you started.
     --8<-- "examples/beanie/app/users.py"
     ```
 
+## SQLModel
+
+[Open :material-open-in-new:](https://github.com/fastapi-users/fastapi-users/tree/master/examples/sqlmodel)
+
+=== "requirements.txt"
+
+    ```
+    --8<-- "examples/sqlmodel/requirements.txt"
+    ```
+
+=== "main.py"
+
+    ```py
+    --8<-- "examples/sqlmodel/main.py"
+    ```
+
+=== "app/app.py"
+
+    ```py
+    --8<-- "examples/sqlmodel/app/app.py"
+    ```
+
+=== "app/db.py"
+
+    ```py
+    --8<-- "examples/sqlmodel/app/db.py"
+    ```
+
+=== "app/schemas.py"
+
+    ```py
+    --8<-- "examples/sqlmodel/app/schemas.py"
+    ```
+
+=== "app/users.py"
+
+    ```py
+    --8<-- "examples/sqlmodel/app/users.py"
+    ```
+
+!!! note
+
+    You will notice that the [SQLModel](https://sqlmodel.tiangolo.com/) example is very similar
+    to the [SQLAlchemy](#sqlalchemy) example. This is because SQLModel is built on top of SQLAlchemy
+    and pydantic.
+
+    There are a few important differences you should take note of:
+
+    #### `app/db.py`
+
+    - Removing the `DeclarativeBase` SQLAlchemy base class.
+    - Using `fastapi_users.db.SQLModelBaseUserDB` instead of
+      `fastapi_users.db.SQLAlchemyBaseUserTable`.
+    - Using `fastapi_users.db.SQLModelUserDatabaseAsync` instead of
+      `fastapi_users.db.SQLAlchemyUserDatabase`.
+    - Setting the `class_` parameter of `sessionmaker` to `AsyncSession`.
+    - Using `SQLModel.metadata.create_all` instead of `Base.metadata.create_all`.
+
+    #### `app/users.py`
+
+    - Using `fastapi_users.db.SQLModelUserDatabaseAsync` instead of
+      `fastapi_users.db.SQLAlchemyUserDatabase`.
+
+
 ## What now?
 
 You're ready to go! Be sure to check the [Usage](../usage/routes.md) section to understand how to work with **FastAPI Users**.

--- a/examples/sqlmodel/app/app.py
+++ b/examples/sqlmodel/app/app.py
@@ -1,0 +1,41 @@
+from app.db import User, create_db_and_tables
+from app.schemas import UserCreate, UserRead, UserUpdate
+from app.users import auth_backend, current_active_user, fastapi_users
+from fastapi import Depends, FastAPI
+
+app = FastAPI()
+
+app.include_router(
+    fastapi_users.get_auth_router(auth_backend), prefix="/auth/jwt", tags=["auth"]
+)
+app.include_router(
+    fastapi_users.get_register_router(UserRead, UserCreate),
+    prefix="/auth",
+    tags=["auth"],
+)
+app.include_router(
+    fastapi_users.get_reset_password_router(),
+    prefix="/auth",
+    tags=["auth"],
+)
+app.include_router(
+    fastapi_users.get_verify_router(UserRead),
+    prefix="/auth",
+    tags=["auth"],
+)
+app.include_router(
+    fastapi_users.get_users_router(UserRead, UserUpdate),
+    prefix="/users",
+    tags=["users"],
+)
+
+
+@app.get("/authenticated-route")
+async def authenticated_route(user: User = Depends(current_active_user)):
+    return {"message": f"Hello {user.email}!"}
+
+
+@app.on_event("startup")
+async def on_startup():
+    # Not needed if you setup a migration system like Alembic
+    await create_db_and_tables()

--- a/examples/sqlmodel/app/db.py
+++ b/examples/sqlmodel/app/db.py
@@ -1,0 +1,37 @@
+from typing import AsyncGenerator
+
+from fastapi import Depends
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import sessionmaker
+from sqlmodel import SQLModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from fastapi_users.db import SQLModelBaseUserDB, SQLModelUserDatabaseAsync
+
+DATABASE_URL = "sqlite+aiosqlite:///./test.db"
+
+
+class User(SQLModelBaseUserDB, table=True):
+    pass
+
+
+engine = create_async_engine(DATABASE_URL, future=True)
+async_session_maker = sessionmaker(
+    engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+
+async def create_db_and_tables():
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+
+async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
+    async with async_session_maker() as session:
+        yield session
+
+
+async def get_user_db(session: AsyncSession = Depends(get_async_session)):
+    yield SQLModelUserDatabaseAsync(session, User)

--- a/examples/sqlmodel/app/schemas.py
+++ b/examples/sqlmodel/app/schemas.py
@@ -1,0 +1,15 @@
+import uuid
+
+from fastapi_users import schemas
+
+
+class UserRead(schemas.BaseUser[uuid.UUID]):
+    pass
+
+
+class UserCreate(schemas.BaseUserCreate):
+    pass
+
+
+class UserUpdate(schemas.BaseUserUpdate):
+    pass

--- a/examples/sqlmodel/app/users.py
+++ b/examples/sqlmodel/app/users.py
@@ -1,0 +1,55 @@
+import uuid
+from typing import Optional
+
+from app.db import User, get_user_db
+from fastapi import Depends, Request
+
+from fastapi_users import BaseUserManager, FastAPIUsers, UUIDIDMixin
+from fastapi_users.authentication import (
+    AuthenticationBackend,
+    BearerTransport,
+    JWTStrategy,
+)
+from fastapi_users.db import SQLModelUserDatabaseAsync
+
+SECRET = "SECRET"
+
+
+class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
+    reset_password_token_secret = SECRET
+    verification_token_secret = SECRET
+
+    async def on_after_register(self, user: User, request: Optional[Request] = None):
+        print(f"User {user.id} has registered.")
+
+    async def on_after_forgot_password(
+        self, user: User, token: str, request: Optional[Request] = None
+    ):
+        print(f"User {user.id} has forgot their password. Reset token: {token}")
+
+    async def on_after_request_verify(
+        self, user: User, token: str, request: Optional[Request] = None
+    ):
+        print(f"Verification requested for user {user.id}. Verification token: {token}")
+
+
+async def get_user_manager(user_db: SQLModelUserDatabaseAsync = Depends(get_user_db)):
+    yield UserManager(user_db)
+
+
+bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
+
+
+def get_jwt_strategy() -> JWTStrategy:
+    return JWTStrategy(secret=SECRET, lifetime_seconds=3600)
+
+
+auth_backend = AuthenticationBackend(
+    name="jwt",
+    transport=bearer_transport,
+    get_strategy=get_jwt_strategy,
+)
+
+fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend])
+
+current_active_user = fastapi_users.current_user(active=True)

--- a/examples/sqlmodel/main.py
+++ b/examples/sqlmodel/main.py
@@ -1,0 +1,4 @@
+import uvicorn
+
+if __name__ == "__main__":
+    uvicorn.run("app.app:app", host="0.0.0.0", log_level="info")

--- a/examples/sqlmodel/requirements.txt
+++ b/examples/sqlmodel/requirements.txt
@@ -1,0 +1,4 @@
+fastapi
+fastapi-users[sqlmodel]
+uvicorn[standard]
+aiosqlite

--- a/fastapi_users/db/__init__.py
+++ b/fastapi_users/db/__init__.py
@@ -34,3 +34,18 @@ try:  # pragma: no cover
     __all__.append("ObjectIDIDMixin")
 except ImportError:  # pragma: no cover
     pass
+
+try:  # pragma: no cover
+    from fastapi_users_db_sqlmodel import (  # noqa: F401
+        SQLModelBaseUserDB,
+        SQLModelBaseOAuthAccount,
+        SQLModelUserDatabase,
+        SQLModelUserDatabaseAsync,
+    )
+
+    __all__.append("SQLModelBaseUserDB")
+    __all__.append("SQLModelBaseOAuthAccount")
+    __all__.append("SQLModelUserDatabase")
+    __all__.append("SQLModelUserDatabaseAsync")
+except ImportError:  # pragma: no cover
+    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,17 @@ lint-check = [
 ]
 docs = "mkdocs serve"
 
+[tool.hatch.envs.sqlmodel]
+features = [
+    "sqlmodel"
+]
+dependencies = [
+    "aiosqlite"
+]
+
+[tool.hatch.envs.sqlmodel.scripts]
+example = "python examples/sqlmodel/main.py"
+
 [tool.hatch.envs.test]
 
 [tool.hatch.envs.test.scripts]
@@ -157,6 +168,9 @@ oauth = [
 ]
 redis = [
     "redis >=4.3.3,<5.0.0",
+]
+sqlmodel = [
+    "fastapi-users-db-sqlmodel >=0.3.0,<1.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR adds a Full Example documentation for FastAPI Users with SQLModel - it also adds a lookup to the existing models at `fastapi_users.db` module.

Relates to:
- https://github.com/fastapi-users/fastapi-users/discussions/1202
- https://github.com/fastapi-users/fastapi-users-db-sqlmodel/issues/2

<img width="812" alt="image" src="https://github.com/fastapi-users/fastapi-users/assets/49741340/67339396-d934-4838-ba89-e4b3ea72fe60">


Test it out with `hatch run sqlmodel:example`