### PR TITLE
Fix password update None handling.

### DIFF
--- a/fastapi_users/manager.py
+++ b/fastapi_users/manager.py
@@ -672,7 +672,7 @@ class BaseUserManager(Generic[models.UP, models.ID]):
                 except exceptions.UserNotExists:
                     validated_update_dict["email"] = value
                     validated_update_dict["is_verified"] = False
-            elif field == "password":
+            elif field == "password" and value is not None:
                 await self.validate_password(value, user)
                 validated_update_dict["hashed_password"] = self.password_helper.hash(
                     value

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -585,6 +585,17 @@ class TestUpdateUser:
 
         assert user_manager.on_after_update.called is True
 
+    async def test_unsafe_update_password_unchanged(
+        self, user: UserModel, user_manager: UserManagerMock[UserModel]
+    ):
+        old_hashed_password = user.hashed_password
+        user_update = UserUpdate(password=None)
+        updated_user = await user_manager.update(user_update, user, safe=False)
+
+        assert updated_user.hashed_password == old_hashed_password
+
+        assert user_manager.on_after_update.called is True
+
     async def test_password_update_invalid(
         self, user: UserModel, user_manager: UserManagerMock[UserModel]
     ):


### PR DESCRIPTION
This PR fixes some simple `None` handling bugs with passwords.

The `BaseUserUpdate` schema supposedly supports the password field as `Optional[str]`, but actually attempting to use a None in this field causes errors. The use case here, for example, is using a frontend form that serializes to JSON an always sets the "password" field as in `{"password": null, ...}`).

Steps to reproduce:
1. Call `user_manager.update` with a schema like `UserUpdate(password=None, ...other fields updated...)`

Current behavior:
* Error on password validation: `TypeError: object of type 'NoneType' has no len()`
* Error without password validation: `TypeError: secret must be unicode or bytes, not None`

New behavior:
* Password will remain unchanged, other fields will get updated