### PR TITLE
Refactored get_by_oauth_account on manager.py 

### DIFF
--- a/fastapi_users/manager.py
+++ b/fastapi_users/manager.py
@@ -98,9 +98,14 @@ class BaseUserManager(Generic[models.UP, models.ID]):
         :param oauth: Name of the OAuth client.
         :param account_id: Id. of the account on the external OAuth service.
         :raises UserNotExists: The user does not exist.
+        :raises NotImplementedError: The OAuthAccount wasn't added to fastapi_users.db base.
         :return: A user.
         """
-        user = await self.user_db.get_by_oauth_account(oauth, account_id)
+        try:
+            user = await self.user_db.get_by_oauth_account(oauth, account_id)
+        except NotImplementedError:
+            print("User manager does not support OAuth accounts. maybe you forgot add OAuthAccount to fastapi_users.db base?")
+            raise NotImplementedError
 
         if user is None:
             raise exceptions.UserNotExists()


### PR DESCRIPTION
to handle missing of OuthAccount on BaseUserDatabase

I went through it not once, but twice. When implementing fastapiusers with OAuth, I forgot to add the 'OAuthAccount' class to the definition of 'BeanieUserDatabase(User, OAuthAccount)' or 'SQLAlchemyUserDatabase(session, User, OAuthAccount)' on db.py example file.

When that happens, the API works fine until the OAuth2 flow is initiated, and the error occurs without knowing exactly where. Perhaps this is a good way to catch the error and save hours of searching and digging into the code to solve the issue.

PS: Enjoy digging into the code.