### PR TITLE
Update cookie.md to reflect correct status code on login

### DIFF
--- a/docs/configuration/authentication/transports/cookie.md
+++ b/docs/configuration/authentication/transports/cookie.md
@@ -24,7 +24,7 @@ As you can see, instantiation is quite simple. It accepts the following argument
 
 This method will return a response with a valid `set-cookie` header upon successful login:
 
-!!! success "`200 OK`"
+!!! success "`204 OK`"
 
 > Check documentation about [login route](../../../usage/routes.md#post-login).
 


### PR DESCRIPTION
I noticed that the response object returned from the `get_login_response` method in the file **_fastapi_users/authentication/transport/cookie.py_** is a 204 instead of a 200.