### PR TITLE
docs: improved snippet for db>sa base user tip for using int as id

### DIFF
--- a/docs/configuration/databases/sqlalchemy.md
+++ b/docs/configuration/databases/sqlalchemy.md
@@ -33,7 +33,9 @@ As you can see, **FastAPI Users** provides a base class that will include base f
     By default, we use UUID as a primary key ID for your user. If you want to use another type, like an auto-incremented integer, you can use `SQLAlchemyBaseUserTable` as base class and define your own `id` column.
 
     ```py
-    class User(SQLAlchemyBaseUserTable[int], Base):
+    from fastapi_users.db import SQLAlchemyBaseUserTable
+    
+    class User(SQLAlchemyBaseUserTable[Mapped[int]], Base):
         id: Mapped[int] = mapped_column(Integer, primary_key=True)
     ```
 


### PR DESCRIPTION
With just `int` as generic type we get type error:
![image](https://github.com/fastapi-users/fastapi-users/assets/47495003/a140a917-c855-42e1-9fc7-0aa1339ce806)
![image](https://github.com/fastapi-users/fastapi-users/assets/47495003/d15ab4e4-1815-4c53-8349-fa8ecdde3165)

After looking at the [source code](https://github.com/fastapi-users/fastapi-users-db-sqlalchemy/blob/main/fastapi_users_db_sqlalchemy/__init__.py#L25) I found, It should be `Mapped[int]`

Added import just for convenience