### PR TITLE
[Issue #1312]:  full examples use lifespan instead of on_startup

### DIFF
--- a/docs/configuration/databases/beanie.md
+++ b/docs/configuration/databases/beanie.md
@@ -40,20 +40,24 @@ Notice that we pass a reference to the `User` model we defined above.
 
 ## Initialize Beanie
 
-When initializing your FastAPI app, it's important that you [**initialize Beanie**](https://roman-right.github.io/beanie/tutorial/initialization/) so it can discover your models. We can achieve this using a startup event handler on the FastAPI app:
+When initializing your FastAPI app, it's important that you [**initialize Beanie**](https://roman-right.github.io/beanie/tutorial/initialization/) so it can discover your models. We can achieve this using [**Lifespan Events**](https://fastapi.tiangolo.com/advanced/events/) on the FastAPI app:
 
 ```py
+from contextlib import asynccontextmanager
 from beanie import init_beanie
 
 
-@app.on_event("startup")
-async def on_startup():
+@asynccontextmanager
+async def lifespan(app: FastAPI):
     await init_beanie(
-        database=db,  # (1)!
+        database=db,
         document_models=[
-            User,  # (2)!
+            User,
         ],
     )
+    yield
+
+app = FastAPI(lifespan=lifespan)
 ```
 
 1. This is the `db` Motor database instance we defined above.

--- a/docs/configuration/databases/beanie.md
+++ b/docs/configuration/databases/beanie.md
@@ -50,9 +50,9 @@ from beanie import init_beanie
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     await init_beanie(
-        database=db,
+        database=db,  # (1)!
         document_models=[
-            User,
+            User,  # (2)!
         ],
     )
     yield

--- a/examples/sqlalchemy/app/app.py
+++ b/examples/sqlalchemy/app/app.py
@@ -1,10 +1,20 @@
+from contextlib import asynccontextmanager
+
 from fastapi import Depends, FastAPI
 
 from app.db import User, create_db_and_tables
 from app.schemas import UserCreate, UserRead, UserUpdate
 from app.users import auth_backend, current_active_user, fastapi_users
 
-app = FastAPI()
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Not needed if you setup a migration system like Alembic
+    await create_db_and_tables()
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
 
 app.include_router(
     fastapi_users.get_auth_router(auth_backend), prefix="/auth/jwt", tags=["auth"]
@@ -34,9 +44,3 @@ app.include_router(
 @app.get("/authenticated-route")
 async def authenticated_route(user: User = Depends(current_active_user)):
     return {"message": f"Hello {user.email}!"}
-
-
-@app.on_event("startup")
-async def on_startup():
-    # Not needed if you setup a migration system like Alembic
-    await create_db_and_tables()


### PR DESCRIPTION
## Description
Following the example in the fastapi documentation the examples using `on_startup()` in the fastapi-users docs now use `lifespan()` instead of `on_startup`.  

## Issue
Closes #1312 
