### PR TITLE
Fix utcnow deprecation warning

### DIFF
--- a/fastapi_users/jwt.py
+++ b/fastapi_users/jwt.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional, Union
 
 import jwt
@@ -22,7 +22,7 @@ def generate_jwt(
 ) -> str:
     payload = data.copy()
     if lifetime_seconds:
-        expire = datetime.utcnow() + timedelta(seconds=lifetime_seconds)
+        expire = datetime.now(timezone.utc) + timedelta(seconds=lifetime_seconds)
         payload["exp"] = expire
     return jwt.encode(payload, _get_secret_value(secret), algorithm=algorithm)
 


### PR DESCRIPTION
I'm seeing the following warning:

```
lib/python3.12/site-packages/fastapi_users/jwt.py:25: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    expire = datetime.utcnow() + timedelta(seconds=lifetime_seconds)
```

To fix it I changed to the timezone aware version. Since it gets serialized directly below I don't think there should be any impact from this change.