### PR TITLE
Add on_after_logout method to user_manager

### DIFF
--- a/docs/configuration/user-manager.md
+++ b/docs/configuration/user-manager.md
@@ -193,6 +193,35 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         print(f"User {user.id} logged in.")
 ```
 
+#### `on_after_logout`
+
+Perform logic after user logout.
+
+Could be useful for analytics or adding redirect targets when called from html forms.
+
+**Arguments**
+
+* `user` (`User`): the updated user.
+* `request` (`Optional[Request]`): optional FastAPI request object that triggered the operation. Defaults to None.
+* `response` (`Optional[Response]`): Optional response built by the transport. Defaults to None.
+
+**Example**
+
+```py
+from fastapi_users import BaseUserManager, UUIDIDMixin
+
+
+class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
+    # ...
+    async def on_after_logout(
+        self,
+        user: User,
+        request: Optional[Request] = None,
+        response: Optional[Response] = None,
+    ):
+        print(f"User {user.id} logged out.")
+```
+
 #### `on_after_request_verify`
 
 Perform logic after successful verification request.

--- a/fastapi_users/authentication/authenticator.py
+++ b/fastapi_users/authentication/authenticator.py
@@ -31,7 +31,9 @@ class DuplicateBackendNamesError(Exception):
     pass
 
 
-EnabledBackendsDependency = DependencyCallable[Sequence[AuthenticationBackend[models.UP, models.ID]]]
+EnabledBackendsDependency = DependencyCallable[
+    Sequence[AuthenticationBackend[models.UP, models.ID]]
+]
 
 
 class Authenticator(Generic[models.UP, models.ID]):
@@ -62,7 +64,9 @@ class Authenticator(Generic[models.UP, models.ID]):
         active: bool = False,
         verified: bool = False,
         superuser: bool = False,
-        get_enabled_backends: Optional[EnabledBackendsDependency[models.UP, models.ID]] = None,
+        get_enabled_backends: Optional[
+            EnabledBackendsDependency[models.UP, models.ID]
+        ] = None,
     ):
         """
         Return a dependency callable to retrieve currently authenticated user and token.
@@ -106,7 +110,9 @@ class Authenticator(Generic[models.UP, models.ID]):
         active: bool = False,
         verified: bool = False,
         superuser: bool = False,
-        get_enabled_backends: Optional[EnabledBackendsDependency[models.UP, models.ID]] = None,
+        get_enabled_backends: Optional[
+            EnabledBackendsDependency[models.UP, models.ID]
+        ] = None,
     ):
         """
         Return a dependency callable to retrieve currently authenticated user.
@@ -157,8 +163,8 @@ class Authenticator(Generic[models.UP, models.ID]):
     ) -> Tuple[Optional[models.UP], Optional[str]]:
         user: Optional[models.UP] = None
         token: Optional[str] = None
-        enabled_backends: Sequence[AuthenticationBackend[models.UP, models.ID]] = kwargs.get(
-            "enabled_backends", self.backends
+        enabled_backends: Sequence[AuthenticationBackend[models.UP, models.ID]] = (
+            kwargs.get("enabled_backends", self.backends)
         )
         for backend in self.backends:
             if backend in enabled_backends:

--- a/fastapi_users/fastapi_users.py
+++ b/fastapi_users/fastapi_users.py
@@ -72,7 +72,9 @@ class FastAPIUsers(Generic[models.UP, models.ID]):
         return get_reset_password_router(self.get_user_manager)
 
     def get_auth_router(
-        self, backend: AuthenticationBackend[models.UP, models.ID], requires_verification: bool = False
+        self,
+        backend: AuthenticationBackend[models.UP, models.ID],
+        requires_verification: bool = False,
     ) -> APIRouter:
         """
         Return an auth router for a given authentication backend.

--- a/fastapi_users/manager.py
+++ b/fastapi_users/manager.py
@@ -605,6 +605,24 @@ class BaseUserManager(Generic[models.UP, models.ID]):
         """
         return  # pragma: no cover
 
+    async def on_after_logout(
+        self,
+        user: models.UP,
+        request: Optional[Request] = None,
+        response: Optional[Response] = None,
+    ) -> None:
+        """
+        Perform logic after user logout.
+
+        *You should overload this method to add your own logic.*
+
+        :param user: The user that logged out
+        :param request: Optional FastAPI request
+        :param response: Optional response built by the transport.
+        Defaults to None
+        """
+        return  # pragma: no cover
+
     async def on_before_delete(
         self, user: models.UP, request: Optional[Request] = None
     ) -> None:

--- a/fastapi_users/router/auth.py
+++ b/fastapi_users/router/auth.py
@@ -83,10 +83,14 @@ def get_auth_router(
         "/logout", name=f"auth:{backend.name}.logout", responses=logout_responses
     )
     async def logout(
+        request: Request,
         user_token: Tuple[models.UP, str] = Depends(get_current_user_token),
         strategy: Strategy[models.UP, models.ID] = Depends(backend.get_strategy),
+        user_manager: BaseUserManager[models.UP, models.ID] = Depends(get_user_manager),
     ):
         user, token = user_token
-        return await backend.logout(strategy, user, token)
+        response = await backend.logout(strategy, user, token)
+        await user_manager.on_after_logout(user, request, response)
+        return response
 
     return router

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,7 @@ class UserManagerMock(BaseTestUserManager[models.UP]):
     on_before_delete: MagicMock
     on_after_delete: MagicMock
     on_after_login: MagicMock
+    on_after_logout: MagicMock
     _update: MagicMock
 
 
@@ -474,6 +475,7 @@ def make_user_manager(mocker: MockerFixture):
         mocker.spy(user_manager, "on_before_delete")
         mocker.spy(user_manager, "on_after_delete")
         mocker.spy(user_manager, "on_after_login")
+        mocker.spy(user_manager, "on_after_logout")
         mocker.spy(user_manager, "_update")
         return user_manager
 

--- a/tests/test_router_auth.py
+++ b/tests/test_router_auth.py
@@ -218,12 +218,17 @@ class TestLogout:
         mocker,
         path,
         test_app_client: Tuple[httpx.AsyncClient, bool],
+        user_manager,
         verified_user: UserModel,
     ):
         client, _ = test_app_client
         response = await client.post(
             path, headers={"Authorization": f"Bearer {verified_user.id}"}
         )
+        assert user_manager.on_after_logout.called is True
+        args, kwargs = user_manager.on_after_logout.call_args
+        assert len(args) == 3
+        assert all(x is not None for x in args)
         assert response.status_code == status.HTTP_200_OK
 
 


### PR DESCRIPTION
Allows to perform custom logic (analytic etc.) after logout for the same reasons as in `on_after_login`.

I am currently using fast-api for serving html content. I know its not the primary use-case for it but its pretty well supported. Because of this login/logout requests come from html forms instead of api calls from javascript so login/logout routes need to handle http redirects. For login requests its easy to handle with the `on_after_login` method on the user_manager but for logouts there is no such option. Currently to add custom redirects to logout requires manually implementing both login and logout routes so having a `on_after_logout` method would make things much more convenient.