### PR TITLE
Fix database URL examples in docs

### DIFF
--- a/docs/configuration/databases/sqlalchemy.md
+++ b/docs/configuration/databases/sqlalchemy.md
@@ -11,8 +11,8 @@ To work with your DBMS, you'll need to install the corresponding asyncio driver.
 
 Examples of `DB_URL`s are:
 
-* PostgreSQL: `engine = create_engine('postgresql+asyncpg://user:password@host:port/name')`
-* SQLite: `engine = create_engine('sqlite+aiosqlite:///name.db')`
+* PostgreSQL: `postgresql+asyncpg://user:password@host:port/name`
+* SQLite: `sqlite+aiosqlite:///name.db`
 
 For the sake of this tutorial from now on, we'll use a simple SQLite database.
 


### PR DESCRIPTION
This PR corrects the database URL examples in the docs. The examples should show only the URL format, not `create_engine`, as this section is about defining the URL, not creating the engine. Including `create_engine` is also misleading, as using async DB interfaces like `asyncpg` requires an async engine (create_async_engine), not a synchronous one. The updated examples show only the correct URL format for Postgresql and Sqlite.