### PR TITLE
Update HTTPX OAuth link oauth.md

### DIFF
--- a/docs/configuration/oauth.md
+++ b/docs/configuration/oauth.md
@@ -18,7 +18,7 @@ pip install 'fastapi-users[beanie,oauth]'
 
 ### Instantiate an OAuth2 client
 
-You first need to get an HTTPX OAuth client instance. [Read the documentation](https://frankie567.github.io/httpx-oauth/oauth2/) for more information.
+You first need to get an HTTPX OAuth client instance. [Read the documentation](https://frankie567.github.io/httpx-oauth/usage/) for more information.
 
 ```py
 from httpx_oauth.clients.google import GoogleOAuth2


### PR DESCRIPTION
The old link was 404, opening some broken/incomplete website:
![Screenshot 2025-04-19 at 10 52 52](https://github.com/user-attachments/assets/ac63d5fb-be96-4b39-a7eb-f89728cffbe0)

Updated the link to point to https://frankie567.github.io/httpx-oauth/usage/.

We could also point directly to the OAuth2 clients reference: https://frankie567.github.io/httpx-oauth/reference/httpx_oauth.clients/