### PR TITLE
feat: Add option to redirect to a specific URL after login

### DIFF
--- a/fastapi_users/authentication/transport/cookie.py
+++ b/fastapi_users/authentication/transport/cookie.py
@@ -19,6 +19,7 @@ class CookieTransport(Transport):
         cookie_secure: bool = True,
         cookie_httponly: bool = True,
         cookie_samesite: Literal["lax", "strict", "none"] = "lax",
+        on_login_redirect_url: Optional[str] = None,
     ):
         self.cookie_name = cookie_name
         self.cookie_max_age = cookie_max_age
@@ -28,9 +29,14 @@ class CookieTransport(Transport):
         self.cookie_httponly = cookie_httponly
         self.cookie_samesite = cookie_samesite
         self.scheme = APIKeyCookie(name=self.cookie_name, auto_error=False)
+        self.on_login_redirect_url = on_login_redirect_url
+
 
     async def get_login_response(self, token: str) -> Response:
-        response = Response(status_code=status.HTTP_204_NO_CONTENT)
+        if self.on_login_redirect_url:
+            response = RedirectResponse(url=self.on_login_redirect_url, status_code=status.HTTP_302_FOUND)
+        else:
+            response = Response(status_code=status.HTTP_204_NO_CONTENT)
         return self._set_login_cookie(response, token)
 
     async def get_logout_response(self) -> Response:


### PR DESCRIPTION
Add a feature to the CookieTransport class to redirect to a specific URL after login. This is useful because currently, a user won't be redirected after logging in via OAuth and will be stuck on the OAuth server's "redirecting"/"successfully logged in" page.

The current fix for this issue is to create another CookieTransport class and overwrite the get_login_response function like this:
```python
class RedirectingCookieTransport(CookieTransport):
    async def get_login_response(self, token: str) -> Response:
        response = RedirectResponse(redirect_url, status_code=status.HTTP_302_FOUND)
        return self._set_login_cookie(response, token)
```
Though I think that this should just be a feature of the library.