### PR TITLE
Docs: fix `:param verified` status code info in `current_user` and `current_user_token` docstrings

### DIFF
--- a/fastapi_users/authentication/authenticator.py
+++ b/fastapi_users/authentication/authenticator.py
@@ -78,7 +78,7 @@ class Authenticator(Generic[models.UP, models.ID]):
         Otherwise, an exception is raised. Defaults to `False`.
         :param active: If `True`, throw `401 Unauthorized` if
         the authenticated user is inactive. Defaults to `False`.
-        :param verified: If `True`, throw `401 Unauthorized` if
+        :param verified: If `True`, throw `403 Forbidden` if
         the authenticated user is not verified. Defaults to `False`.
         :param superuser: If `True`, throw `403 Forbidden` if
         the authenticated user is not a superuser. Defaults to `False`.
@@ -124,7 +124,7 @@ class Authenticator(Generic[models.UP, models.ID]):
         Otherwise, an exception is raised. Defaults to `False`.
         :param active: If `True`, throw `401 Unauthorized` if
         the authenticated user is inactive. Defaults to `False`.
-        :param verified: If `True`, throw `401 Unauthorized` if
+        :param verified: If `True`, throw `403 Forbidden` if
         the authenticated user is not verified. Defaults to `False`.
         :param superuser: If `True`, throw `403 Forbidden` if
         the authenticated user is not a superuser. Defaults to `False`.


### PR DESCRIPTION
Closes #1541