### PR TITLE
fix: correct logout OpenAPI response code to 204

### DIFF
--- a/fastapi_users/router/auth.py
+++ b/fastapi_users/router/auth.py
@@ -69,16 +69,19 @@ def get_auth_router(
         return response
 
     logout_responses: OpenAPIResponseType = {
-        **{
-            status.HTTP_401_UNAUTHORIZED: {
-                "description": "Missing token or inactive user."
-            }
+        status.HTTP_204_NO_CONTENT: {
+            "description": "Successfully logged out."
         },
-        **backend.transport.get_openapi_logout_responses_success(),
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Missing token or inactive user."
+        },
     }
 
     @router.post(
-        "/logout", name=f"auth:{backend.name}.logout", responses=logout_responses
+        "/logout",
+        name=f"auth:{backend.name}.logout",
+        status_code=status.HTTP_204_NO_CONTENT,
+        responses=logout_responses,
     )
     async def logout(
         user_token: tuple[models.UP, str] = Depends(get_current_user_token),


### PR DESCRIPTION
### Description
This PR fixes an inconsistency between the actual behavior of the logout endpoint and its OpenAPI documentation.

At runtime, the logout endpoint correctly returns HTTP 204 (No Content), indicating a successful logout without a response body. However, the generated OpenAPI/Swagger documentation previously displayed a 200 OK response, which could be misleading for API consumers and client code generators.

This change ensures that the documented response accurately reflects the real behavior of the endpoint.

### Changes
- Explicitly defined 204 No Content as the success response for the logout endpoint
- Added an OpenAPI response description for the 204 status code
- Ensured the route decorator explicitly sets `status_code=204` so runtime behavior and documentation remain consistent

### Impact
- No changes to authentication or logout logic
- No breaking changes to the public API
- Improves correctness and clarity of the OpenAPI schema
- Aligns Swagger UI documentation with actual HTTP semantics

### Related Issue
Closes #1452
