### PR TITLE
docs: modernize python type signature in schemas guide

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -777,14 +777,26 @@
       "contributions": [
         "bug"
       ]
+    },
+    { 
+      "contributorsPerLine": 7,
+      "projectName": "fastapi-users",
+      "projectOwner": "fastapi-users",
+      "repoType": "github",
+      "repoHost": "https://github.com",
+      "skipCi": true,
+      "commitConvention": "angular",
+      "commitType": "docs"
+    },
+    {
+      "login": "Evarline",
+      "name": "Evarline Mipata",
+      "avatar_url": "https://avatars.githubusercontent.com/u/158709159?v=4",
+      "profile": "https://github.com/Evarline",
+      "contributions": [
+        "doc"
+    ]
     }
-  ],
-  "contributorsPerLine": 7,
-  "projectName": "fastapi-users",
-  "projectOwner": "fastapi-users",
-  "repoType": "github",
-  "repoHost": "https://github.com",
-  "skipCi": true,
-  "commitConvention": "angular",
-  "commitType": "docs"
+  ]
 }
+

--- a/docs/configuration/schemas.md
+++ b/docs/configuration/schemas.md
@@ -56,17 +56,17 @@ from fastapi_users import schemas
 
 class UserRead(schemas.BaseUser[uuid.UUID]):
     first_name: str
-    birthdate: datetime.date | None
+    birthdate: datetime.date | None = None
 
 
 class UserCreate(schemas.BaseUserCreate):
     first_name: str
-    birthdate: datetime.date | None
+    birthdate: datetime.date | None = None
 
 
 class UserUpdate(schemas.BaseUserUpdate):
-    first_name: str | None
-    birtdate: datetime.date | None = None
+    first_name: str | None = None
+    birthdate: datetime.date | None = None
 ```
 
 !!! warning "Make sure to mirror this in your database model"

--- a/docs/configuration/schemas.md
+++ b/docs/configuration/schemas.md
@@ -56,17 +56,17 @@ from fastapi_users import schemas
 
 class UserRead(schemas.BaseUser[uuid.UUID]):
     first_name: str
-    birthdate: Optional[datetime.date]
+    birthdate: datetime.date | None
 
 
 class UserCreate(schemas.BaseUserCreate):
     first_name: str
-    birthdate: Optional[datetime.date]
+    birthdate: datetime.date | None
 
 
 class UserUpdate(schemas.BaseUserUpdate):
-    first_name: Optional[str]
-    birthdate: Optional[datetime.date]
+    first_name: str | None
+    birtdate: datetime.date | None = None
 ```
 
 !!! warning "Make sure to mirror this in your database model"


### PR DESCRIPTION
##Modern Python type signature
-This pr modernizes the python type signature in the  'schemas.md' configuration guide to use standard pipe operator union types